### PR TITLE
Correct DNS resolver settings

### DIFF
--- a/terraform/networking/subnets.tf
+++ b/terraform/networking/subnets.tf
@@ -14,12 +14,6 @@ resource "azurerm_subnet_route_table_association" "rt_assocation_complex_cases_a
   depends_on     = [azurerm_subnet.sn_complex_cases_ampls_subnet]
 }
 
-resource "azurerm_subnet_network_security_group_association" "nsg_association_complex_cases_ampls_subnet" {
-  network_security_group_id = data.azurerm_network_security_group.complex_cases_nsg.id
-  subnet_id                 = azurerm_subnet.sn_complex_cases_ampls_subnet.id
-  depends_on                = [azurerm_subnet.sn_complex_cases_ampls_subnet]
-}
-
 ################################
 
 resource "azurerm_subnet" "sn_complex_cases_dns_resolver_inbound_subnet" {
@@ -40,18 +34,6 @@ resource "azurerm_subnet" "sn_complex_cases_dns_resolver_inbound_subnet" {
   depends_on = [data.azurerm_virtual_network.complex_cases_vnet]
 }
 
-resource "azurerm_subnet_route_table_association" "rt_assocation_complex_cases_dnsResolverInbound_subnet" {
-  route_table_id = data.azurerm_route_table.complex_cases_rt.id
-  subnet_id      = azurerm_subnet.sn_complex_cases_dns_resolver_inbound_subnet.id
-  depends_on     = [azurerm_subnet.sn_complex_cases_dns_resolver_inbound_subnet]
-}
-
-resource "azurerm_subnet_network_security_group_association" "nsg_association_complex_cases_dnsResolverInbound_subnet" {
-  network_security_group_id = data.azurerm_network_security_group.complex_cases_nsg.id
-  subnet_id                 = azurerm_subnet.sn_complex_cases_dns_resolver_inbound_subnet.id
-  depends_on                = [azurerm_subnet.sn_complex_cases_dns_resolver_inbound_subnet]
-}
-
 ################################
 
 resource "azurerm_subnet" "sn_complex_cases_dns_resolver_outbound_subnet" {
@@ -70,16 +52,4 @@ resource "azurerm_subnet" "sn_complex_cases_dns_resolver_outbound_subnet" {
   }
 
   depends_on = [data.azurerm_virtual_network.complex_cases_vnet]
-}
-
-resource "azurerm_subnet_route_table_association" "rt_assocation_complex_cases_dnsResolverOutbound_subnet" {
-  route_table_id = data.azurerm_route_table.complex_cases_rt.id
-  subnet_id      = azurerm_subnet.sn_complex_cases_dns_resolver_outbound_subnet.id
-  depends_on     = [azurerm_subnet.sn_complex_cases_dns_resolver_outbound_subnet]
-}
-
-resource "azurerm_subnet_network_security_group_association" "nsg_association_complex_cases_dnsResolverOutbound_subnet" {
-  network_security_group_id = data.azurerm_network_security_group.complex_cases_nsg.id
-  subnet_id                 = azurerm_subnet.sn_complex_cases_dns_resolver_outbound_subnet.id
-  depends_on                = [azurerm_subnet.sn_complex_cases_dns_resolver_outbound_subnet]
 }

--- a/terraform/networking/subnets.tf
+++ b/terraform/networking/subnets.tf
@@ -1,4 +1,5 @@
 resource "azurerm_subnet" "sn_complex_cases_ampls_subnet" {
+  #checkov:skip=CKV2_AZURE_31:Ensure VNET subnet is configured with a Network Security Group (NSG)
   name                 = "${local.product_name}-ampls-subnet"
   resource_group_name  = data.azurerm_resource_group.networking_resource_group.name
   virtual_network_name = data.azurerm_virtual_network.complex_cases_vnet.name
@@ -17,6 +18,7 @@ resource "azurerm_subnet_route_table_association" "rt_assocation_complex_cases_a
 ################################
 
 resource "azurerm_subnet" "sn_complex_cases_dns_resolver_inbound_subnet" {
+  #checkov:skip=CKV2_AZURE_31:Ensure VNET subnet is configured with a Network Security Group (NSG)
   name                 = "${local.product_name}-dns-resolve-inbound-subnet"
   resource_group_name  = data.azurerm_resource_group.networking_resource_group.name
   virtual_network_name = data.azurerm_virtual_network.complex_cases_vnet.name
@@ -37,6 +39,7 @@ resource "azurerm_subnet" "sn_complex_cases_dns_resolver_inbound_subnet" {
 ################################
 
 resource "azurerm_subnet" "sn_complex_cases_dns_resolver_outbound_subnet" {
+  #checkov:skip=CKV2_AZURE_31:Ensure VNET subnet is configured with a Network Security Group (NSG)
   name                 = "${local.product_name}-dns-resolve-outbound-subnet"
   resource_group_name  = data.azurerm_resource_group.networking_resource_group.name
   virtual_network_name = data.azurerm_virtual_network.complex_cases_vnet.name


### PR DESCRIPTION
Removed route table and NSG association from DNS resolver inbound and outbound definitions. This was causing resolution failures. Removed scale set's NSG from AMPLS subnet too.