### PR TITLE
fix issue exceeding command-line length limit

### DIFF
--- a/devops-pipelines/scripts/test-automation-cleanup/Clear-EgressFolder.ps1
+++ b/devops-pipelines/scripts/test-automation-cleanup/Clear-EgressFolder.ps1
@@ -102,19 +102,35 @@ else {
 # ============================================================
 Write-Host "[3/3] Deleting $($filesToDelete.Count) file(s)..." -ForegroundColor Yellow
 
-
 $fileIds = @($filesToDelete | Select-Object -ExpandProperty id)
 
-try {
-  Remove-EgressFiles `
-    -BaseUrl $BaseUrl `
-    -AuthorizationHeader $AuthHeader `
-    -WorkspaceId $WorkspaceId `
-    -FileIds $fileIds
-}
-catch {
-  Write-Error $_.Exception.Message
-  exit 1
+# Batching fileIds into arrays of max 100 strings to avoid exceeding command‑line length limit:
+$batchSize = 100
+$totalBatches = [math]::Ceiling($fileIds.Count / $batchSize)
+
+for ($i = 0; $i -lt $fileIds.Count; $i += $batchSize) {
+  $batch = $fileIds[$i..([math]::Min($i + $batchSize - 1, $fileIds.Count - 1))]  
+  $batchIndex = [int]($i / $batchSize) + 1
+
+  Write-Host ("Deleting batch {0}/{1} ({2} file(s))..." -f `
+    $batchIndex, $totalBatches, $batch.Count)
+
+  try {
+    Remove-EgressFiles `
+      -BaseUrl $BaseUrl `
+      -AuthorizationHeader $AuthHeader `
+      -WorkspaceId $WorkspaceId `
+      -FileIds $batch
+      
+    Write-Host ("Batch {0}/{1} completed successfully." -f `
+      $batchIndex, $totalBatches)
+
+  }
+  catch {
+    Write-Host "Failed to delete files: $($_.Exception.Message)" -ForegroundColor Red
+    Write-Error $_
+    exit 1
+  }
 }
 
 Write-Host "  [OK] All files deleted successfully." -ForegroundColor Green

--- a/devops-pipelines/scripts/test-automation-cleanup/EgressCleanupHelperModule.psm1
+++ b/devops-pipelines/scripts/test-automation-cleanup/EgressCleanupHelperModule.psm1
@@ -15,7 +15,8 @@ function Connect-EgressServiceAccount {
         Accept        = "application/json"
         Authorization = "Basic $AuthToken"
       } `
-      -ContentType 'application/json'
+      -ContentType 'application/json' `
+      -ErrorAction Stop
   }
   catch {
     throw "Authentication failed: $($_.Exception.Message)"
@@ -50,9 +51,7 @@ function Remove-EgressFiles {
     [string[]]$FileIds
   )
 
-  $headers =  $AuthorizationHeader + @{
-    "Content-Type" = "application/json"
-  }
+  $headers =  $AuthorizationHeader
 
   $body = @{
     file_ids = $FileIds
@@ -62,7 +61,8 @@ function Remove-EgressFiles {
     -Uri "$BaseUrl/api/v1/workspaces/$WorkspaceId/files" `
     -Headers $headers `
     -Body $body `
-    -ContentType 'application/json'
+    -ContentType 'application/json' `
+    -ErrorAction Stop
   
   $failed = $response.results | Where-Object { $_.code -ne 0 }
 
@@ -74,6 +74,5 @@ function Remove-EgressFiles {
     throw "One or more files failed to delete."
   }
 }
-
 
 Export-ModuleMember -Function Connect-EgressServiceAccount, Remove-EgressFiles


### PR DESCRIPTION
The Issue: 
When passing an array of > 100 IDs, Clear-EgressFolder script was failing to execute the Remove-EgressFiles function due to exceeding the command-line length limit.
The Fix:
Execute the function for batches of 100 IDs or under.
