### PR TITLE
change cleanup pipeline to only trigger on weekdays

### DIFF
--- a/devops-pipelines/cleanup-testfiles.yml
+++ b/devops-pipelines/cleanup-testfiles.yml
@@ -1,6 +1,6 @@
 schedules:
-  - cron: '0 3 * * *'
-    displayName: 'Daily 3am UTC cleanup'
+  - cron: '0 3 * * Tue-Sat'
+    displayName: 'Weekday 3am UTC cleanup'
     branches:
       include:
         - main


### PR DESCRIPTION
Setting cleanup cron job to only trigger early AM Tue-Sat, as no tests are expected to run over the weekend