### PR TITLE
update pipeline templates to set ASPNETCORE_ENVIRONMENT

### DIFF
--- a/devops-pipelines/templates/fa-config-steps.yml
+++ b/devops-pipelines/templates/fa-config-steps.yml
@@ -268,5 +268,15 @@ steps:
             "name": "DOTNET_FRAMEWORK_VERSION",
             "value": "v8.0",
             "slotSetting": false
+          },
+          {
+            "name": "ASPNETCORE_ENVIRONMENT",
+            "value": "$(AspNetCoreEnvironment)",
+            "slotSetting": false
+          },
+          {
+            "name": "AZURE_FUNCTIONS_ENVIRONMENT",
+            "value": "$(AzureFunctionsEnvironment)",
+            "slotSetting": false
           }
         ]

--- a/devops-pipelines/templates/variables/fa-config-dev.yml
+++ b/devops-pipelines/templates/variables/fa-config-dev.yml
@@ -1,4 +1,8 @@
 variables:
+  - name: AspNetCoreEnvironment
+    value: "PreProd"
+  - name: AzureFunctionsEnvironment
+    value: "PreProd"
   - name: CryptoOptionsKeySizeBytes
     value: "32"
   - name: CryptoOptionsNonceSizeBytes

--- a/devops-pipelines/templates/variables/fa-config-prod.yml
+++ b/devops-pipelines/templates/variables/fa-config-prod.yml
@@ -1,4 +1,8 @@
 variables:
+  - name: AspNetCoreEnvironment
+    value: "Production"
+  - name: AzureFunctionsEnvironment
+    value: "Production"
   - name: CryptoOptionsKeySizeBytes
     value: "32"
   - name: CryptoOptionsNonceSizeBytes

--- a/devops-pipelines/templates/variables/fa-config-staging.yml
+++ b/devops-pipelines/templates/variables/fa-config-staging.yml
@@ -1,4 +1,8 @@
 variables:
+  - name: AspNetCoreEnvironment
+    value: "PreProd"
+  - name: AzureFunctionsEnvironment
+    value: "PreProd"
   - name: CryptoOptionsKeySizeBytes
     value: "32"
   - name: CryptoOptionsNonceSizeBytes


### PR DESCRIPTION
- update fa-config-steps to set a value for `ASPNETCORE_ENVIRONMENT`
- update per-env variables to include the safe values (PreProd / Production)

Not in scope but I thought it made sense to add this too:
- update same as above with the env var `AZURE_FUNCTIONS_ENVIRONMENT`