### PR TITLE
chore: raise NetApp S3 key TTL to 4 hours across all environments

### DIFF
--- a/backend/CPS.ComplexCases.API/local.settings.example.json
+++ b/backend/CPS.ComplexCases.API/local.settings.example.json
@@ -19,7 +19,7 @@
     "NetAppOptions__Url": "https://<NetApp URL>/",
     "NetAppOptions__ClusterUrl": "https://<NetApp Cluster URL>/",
     "NetAppOptions__RegionName": "eu-west-1",
-    "NetAppOptions__SessionDurationSeconds": "3600",
+    "NetAppOptions__SessionDurationSeconds": "14400",
     "NetAppOptions__S3ServiceUuid": "<Your NetApp S3 service UUID>",
     "NetAppOptions__PepperVersion": "v1",
     "NetAppOptions__SearchMaxSubstringScanItems": "10000",

--- a/backend/CPS.ComplexCases.FileTransfer.API/local.settings.example.json
+++ b/backend/CPS.ComplexCases.FileTransfer.API/local.settings.example.json
@@ -15,7 +15,7 @@
     "NetAppOptions__Url": "https://<NetApp URL>/",
     "NetAppOptions__ClusterUrl": "https://<NetApp Cluster URL>/",
     "NetAppOptions__RegionName": "eu-west-1",
-    "NetAppOptions__SessionDurationSeconds": "3600",
+    "NetAppOptions__SessionDurationSeconds": "14400",
     "NetAppOptions__S3ServiceUuid": "<Your NetApp S3 service UUID>",
     "NetAppOptions__PepperVersion": "v1",
     "NetAppOptions__RequestTimeoutSeconds": "100",

--- a/backend/CPS.ComplexCases.NetApp/Models/NetAppOptions.cs
+++ b/backend/CPS.ComplexCases.NetApp/Models/NetAppOptions.cs
@@ -5,7 +5,7 @@ namespace CPS.ComplexCases.NetApp.Models
         public required string Url { get; set; }
         public required string RegionName { get; set; }
         public Guid S3ServiceUuid { get; set; } = Guid.Empty;
-        public int SessionDurationSeconds { get; set; } = 3600;
+        public int SessionDurationSeconds { get; set; } = 14400;
         public string PepperVersion { get; set; } = "v1";
         public string RootCaCert { get; set; } = string.Empty;
         public string IssuingCaCert { get; set; } = string.Empty;

--- a/devops-pipelines/templates/variables/fa-config-dev.yml
+++ b/devops-pipelines/templates/variables/fa-config-dev.yml
@@ -28,7 +28,7 @@ variables:
   - name: NetAppOptionsPepperVersion
     value: "v1"
   - name: NetAppOptionsSessionDurationSeconds
-    value: "3600"
+    value: "14400"
   - name: RateLimitingIntervalInSeconds
     value: "60"
   - name: RateLimitingPermitLimit

--- a/devops-pipelines/templates/variables/fa-config-prod.yml
+++ b/devops-pipelines/templates/variables/fa-config-prod.yml
@@ -28,7 +28,7 @@ variables:
   - name: NetAppOptionsPepperVersion
     value: "v1"
   - name: NetAppOptionsSessionDurationSeconds
-    value: "3600"
+    value: "14400"
   - name: RateLimitingIntervalInSeconds
     value: "60"
   - name: RateLimitingPermitLimit

--- a/devops-pipelines/templates/variables/fa-config-staging.yml
+++ b/devops-pipelines/templates/variables/fa-config-staging.yml
@@ -28,7 +28,7 @@ variables:
   - name: NetAppOptionsPepperVersion
     value: "v1"
   - name: NetAppOptionsSessionDurationSeconds
-    value: "3600"
+    value: "14400"
   - name: RateLimitingIntervalInSeconds
     value: "60"
   - name: RateLimitingPermitLimit


### PR DESCRIPTION
# PR checklist

## Correctness
- [&#x2611; ] Does what the ticket asks for

## Keeping it simple
- [&#x2611; ] Doesn't rebuild something that already exists in the codebase
- [ &#x2611;] No more complex or slower than it needs to be
- [&#x2611; ] No leftover debug logging or commented-out code

## Easy to miss (a green pipeline won't flag these)
- [&#x2611; ] One logical change, not a pile of unrelated stuff

### If you touched the backend
- [ &#x2611;] New app settings are wired into the fa-config templates
