### PR TITLE
Defect/FCT2-20525: show full NetApp source path in activity log

### DIFF
--- a/backend/CPS.ComplexCases.FileTransfer.API.Tests/Unit/Durable/Activity/UpdateActivityLogTests.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API.Tests/Unit/Durable/Activity/UpdateActivityLogTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.DurableTask.Client.Entities;
 using Microsoft.DurableTask.Entities;
 using Microsoft.Extensions.Logging;
@@ -8,6 +9,8 @@ using CPS.ComplexCases.ActivityLog.Services;
 using CPS.ComplexCases.Common.Handlers;
 using CPS.ComplexCases.Common.Models.Domain.Enums;
 using CPS.ComplexCases.Common.Models.Requests;
+using CPS.ComplexCases.Common.Services;
+using CPS.ComplexCases.Data.Entities;
 using CPS.ComplexCases.FileTransfer.API.Durable.Activity;
 using CPS.ComplexCases.FileTransfer.API.Durable.Payloads;
 using CPS.ComplexCases.FileTransfer.API.Durable.Payloads.Domain;
@@ -23,6 +26,7 @@ public class UpdateActivityLogTests
     private readonly Mock<IActivityLogService> _activityLogServiceMock;
     private readonly Mock<ILogger<UpdateActivityLog>> _loggerMock;
     private readonly Mock<IInitializationHandler> _initializationHandlerMock;
+    private readonly Mock<ICaseMetadataService> _caseMetadataServiceMock;
     private readonly DurableEntityClientStub _durableEntityClientStub;
     private readonly DurableTaskClientStub _durableTaskClientStub;
     private readonly UpdateActivityLog _activity;
@@ -36,11 +40,12 @@ public class UpdateActivityLogTests
         _activityLogServiceMock = new Mock<IActivityLogService>();
         _loggerMock = new Mock<ILogger<UpdateActivityLog>>();
         _initializationHandlerMock = new Mock<IInitializationHandler>();
+        _caseMetadataServiceMock = new Mock<ICaseMetadataService>();
 
         _durableEntityClientStub = new DurableEntityClientStub("TestClient");
         _durableTaskClientStub = new DurableTaskClientStub(_durableEntityClientStub);
 
-        _activity = new UpdateActivityLog(_activityLogServiceMock.Object, _loggerMock.Object, _initializationHandlerMock.Object);
+        _activity = new UpdateActivityLog(_activityLogServiceMock.Object, _loggerMock.Object, _initializationHandlerMock.Object, _caseMetadataServiceMock.Object);
         _bearerToken = _fixture.Create<string>();
     }
 
@@ -73,6 +78,132 @@ public class UpdateActivityLogTests
             _activity.Run(null!, _durableTaskClientStub));
 
         Assert.Equal("payload", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Run_ShowsFullNetappSourcePath_ForNetAppToEgress()
+    {
+        // Arrange
+        var transferId = _fixture.Create<Guid>();
+        var userName = _fixture.Create<string>();
+        var caseId = _fixture.Create<int>();
+
+        _caseMetadataServiceMock
+            .Setup(x => x.GetCaseMetadataForCaseIdAsync(caseId))
+            .ReturnsAsync(new CaseMetadata { CaseId = caseId, NetappFolderPath = "LCCDemo2" });
+
+        var entityState = new TransferEntity
+        {
+            Id = transferId,
+            CaseId = caseId,
+            Direction = TransferDirection.NetAppToEgress,
+            TransferType = TransferType.Copy,
+            TotalFiles = 1,
+            DestinationPath = "/dest/path",
+            SourceRootFolderPath = "preview",
+            BearerToken = _bearerToken,
+            SourcePaths = [],
+            SuccessfulItems =
+            [
+                new TransferItem
+            {
+                SourcePath = "LCCDemo2/preview/8mb.txt",
+                Size = 1024,
+                IsRenamed = false,
+                Status = TransferItemStatus.Completed
+            }
+            ],
+            FailedItems = []
+        };
+
+        _durableEntityClientStub.OnGetEntityAsync = (id, token) =>
+            Task.FromResult<EntityMetadata<TransferEntity>?>(new EntityMetadata<TransferEntity>(
+                new Microsoft.DurableTask.Entities.EntityInstanceId("TransferEntity", transferId.ToString()),
+                entityState
+            ));
+
+        JsonDocument? capturedDetails = null;
+        _activityLogServiceMock
+            .Setup(service => service.CreateActivityLogAsync(
+                It.IsAny<ActionType>(),
+                It.IsAny<ResourceType>(),
+                It.IsAny<int>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<JsonDocument>()))
+            .Callback<ActionType, ResourceType, int, string, string, string, JsonDocument>(
+                (_, _, _, _, _, _, details) => capturedDetails = details)
+            .Returns(Task.CompletedTask);
+
+        var payload = new UpdateActivityLogPayload
+        {
+            TransferId = transferId.ToString(),
+            ActionType = ActionType.TransferCompleted,
+            UserName = userName
+        };
+
+        // Act
+        await _activity.Run(payload, _durableTaskClientStub);
+
+        // Assert: the source shows the full NetApp path including the case root folder (matching how
+        // the NetApp destination is shown for the reverse transfer), and the file paths stay full so
+        // the UI file list resolves relative to that source.
+        Assert.NotNull(capturedDetails);
+        var root = capturedDetails!.RootElement;
+        Assert.Equal("LCCDemo2/preview", root.GetProperty("sourcePath").GetString());
+        Assert.Equal("LCCDemo2/preview/8mb.txt", root.GetProperty("files")[0].GetProperty("path").GetString());
+    }
+
+    [Fact]
+    public async Task Run_DoesNotDoublePrefixSource_WhenSourceRootAlreadyIncludesTheRoot()
+    {
+        var caseId = _fixture.Create<int>();
+        _caseMetadataServiceMock
+            .Setup(x => x.GetCaseMetadataForCaseIdAsync(caseId))
+            .ReturnsAsync(new CaseMetadata { CaseId = caseId, NetappFolderPath = "LCCDemo2" });
+
+        // Source root was never stripped (for example, case metadata was missing when the files
+        // were listed), so it already includes the root and must not be doubled.
+        var entityState = BuildNetAppToEgressEntity(_fixture.Create<Guid>(), caseId, "LCCDemo2/preview", "LCCDemo2/preview/8mb.txt");
+
+        var details = await RunAndCaptureDetailsAsync(entityState);
+
+        Assert.NotNull(details);
+        Assert.Equal("LCCDemo2/preview", details!.RootElement.GetProperty("sourcePath").GetString());
+    }
+
+    [Fact]
+    public async Task Run_LeavesSourceRelative_WhenCaseHasNoNetappFolderPath()
+    {
+        var caseId = _fixture.Create<int>();
+        _caseMetadataServiceMock
+            .Setup(x => x.GetCaseMetadataForCaseIdAsync(caseId))
+            .ReturnsAsync(new CaseMetadata { CaseId = caseId, NetappFolderPath = null });
+
+        var entityState = BuildNetAppToEgressEntity(_fixture.Create<Guid>(), caseId, "preview", "LCCDemo2/preview/8mb.txt");
+
+        var details = await RunAndCaptureDetailsAsync(entityState);
+
+        Assert.NotNull(details);
+        Assert.Equal("preview", details!.RootElement.GetProperty("sourcePath").GetString());
+    }
+
+    [Fact]
+    public async Task Run_FallsBackToRelativeSource_WhenCaseMetadataLookupThrows()
+    {
+        var caseId = _fixture.Create<int>();
+        _caseMetadataServiceMock
+            .Setup(x => x.GetCaseMetadataForCaseIdAsync(caseId))
+            .ThrowsAsync(new InvalidOperationException("metadata store unavailable"));
+
+        var entityState = BuildNetAppToEgressEntity(_fixture.Create<Guid>(), caseId, "preview", "LCCDemo2/preview/8mb.txt");
+
+        // A lookup failure must not stop the log; the source falls back to the case-root-relative value.
+        var details = await RunAndCaptureDetailsAsync(entityState);
+
+        Assert.NotNull(details);
+        Assert.Equal("preview", details!.RootElement.GetProperty("sourcePath").GetString());
     }
 
     [Fact]
@@ -463,5 +594,65 @@ public class UpdateActivityLogTests
             It.Is<System.Text.Json.JsonDocument>(doc =>
                 doc.RootElement.GetProperty("sourcePath").GetString() == expectedPath)),
             Times.Once);
+    }
+
+    private TransferEntity BuildNetAppToEgressEntity(Guid transferId, int caseId, string? sourceRootFolderPath, string fileSourcePath)
+    {
+        return new TransferEntity
+        {
+            Id = transferId,
+            CaseId = caseId,
+            Direction = TransferDirection.NetAppToEgress,
+            TransferType = TransferType.Copy,
+            TotalFiles = 1,
+            DestinationPath = "/dest/path",
+            SourceRootFolderPath = sourceRootFolderPath,
+            BearerToken = _bearerToken,
+            SourcePaths = [],
+            SuccessfulItems =
+            [
+                new TransferItem
+            {
+                SourcePath = fileSourcePath,
+                Size = 1024,
+                IsRenamed = false,
+                Status = TransferItemStatus.Completed
+            }
+            ],
+            FailedItems = []
+        };
+    }
+
+    private async Task<JsonDocument?> RunAndCaptureDetailsAsync(TransferEntity entityState)
+    {
+        _durableEntityClientStub.OnGetEntityAsync = (id, token) =>
+            Task.FromResult<EntityMetadata<TransferEntity>?>(new EntityMetadata<TransferEntity>(
+                new Microsoft.DurableTask.Entities.EntityInstanceId("TransferEntity", entityState.Id.ToString()),
+                entityState
+            ));
+
+        JsonDocument? capturedDetails = null;
+        _activityLogServiceMock
+            .Setup(service => service.CreateActivityLogAsync(
+                It.IsAny<ActionType>(),
+                It.IsAny<ResourceType>(),
+                It.IsAny<int>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<JsonDocument>()))
+            .Callback<ActionType, ResourceType, int, string, string, string, JsonDocument>(
+                (_, _, _, _, _, _, details) => capturedDetails = details)
+            .Returns(Task.CompletedTask);
+
+        var payload = new UpdateActivityLogPayload
+        {
+            TransferId = entityState.Id.ToString(),
+            ActionType = ActionType.TransferCompleted,
+            UserName = _fixture.Create<string>()
+        };
+
+        await _activity.Run(payload, _durableTaskClientStub);
+        return capturedDetails;
     }
 }

--- a/backend/CPS.ComplexCases.FileTransfer.API/Durable/Activity/UpdateActivityLog.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Durable/Activity/UpdateActivityLog.cs
@@ -8,6 +8,7 @@ using CPS.ComplexCases.ActivityLog.Models;
 using CPS.ComplexCases.ActivityLog.Services;
 using CPS.ComplexCases.Common.Handlers;
 using CPS.ComplexCases.Common.Models.Domain.Enums;
+using CPS.ComplexCases.Common.Services;
 using CPS.ComplexCases.FileTransfer.API.Durable.Helpers;
 using CPS.ComplexCases.FileTransfer.API.Durable.Payloads;
 using CPS.ComplexCases.FileTransfer.API.Durable.Payloads.Domain;
@@ -15,11 +16,12 @@ using CPS.ComplexCases.FileTransfer.API.Durable.State;
 
 namespace CPS.ComplexCases.FileTransfer.API.Durable.Activity;
 
-public class UpdateActivityLog(IActivityLogService activityLogService, ILogger<UpdateActivityLog> logger, IInitializationHandler initializationHandler)
+public class UpdateActivityLog(IActivityLogService activityLogService, ILogger<UpdateActivityLog> logger, IInitializationHandler initializationHandler, ICaseMetadataService caseMetadataService)
 {
     private readonly IActivityLogService _activityLogService = activityLogService;
     private readonly ILogger<UpdateActivityLog> _logger = logger;
     private readonly IInitializationHandler _initializationHandler = initializationHandler;
+    private readonly ICaseMetadataService _caseMetadataService = caseMetadataService;
 
     [Function(nameof(UpdateActivityLog))]
     public async Task Run([ActivityTrigger] UpdateActivityLogPayload payload, [DurableClient] DurableTaskClient client)
@@ -42,6 +44,26 @@ public class UpdateActivityLog(IActivityLogService activityLogService, ILogger<U
             throw new InvalidOperationException($"Transfer entity with ID {payload.TransferId} not found.");
         }
 
+        // For NetApp to Egress the case's NetApp root folder is stored in case metadata. The file
+        // paths in state are full NetApp paths that include it, and the source root in state has it
+        // stripped. Fetch the root so the source can be shown as the full path (below), matching how
+        // the NetApp destination is shown for the reverse transfer. The full source is a display
+        // nicety, so a lookup failure falls back to the case-root-relative source rather than
+        // stopping the activity log being written.
+        string? netappRootFolderPath = null;
+        if (entity.State.Direction == TransferDirection.NetAppToEgress)
+        {
+            try
+            {
+                var caseMetadata = await _caseMetadataService.GetCaseMetadataForCaseIdAsync(entity.State.CaseId);
+                netappRootFolderPath = caseMetadata?.NetappFolderPath;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Could not read the NetApp folder path for case {CaseId}. The activity log source will be shown relative to the case root.", entity.State.CaseId);
+            }
+        }
+
         var successfulItems = entity.State.SuccessfulItems.Select(x => new FileTransferItem
         {
             Path = x.SourcePath,
@@ -62,6 +84,15 @@ public class UpdateActivityLog(IActivityLogService activityLogService, ILogger<U
             ?? Path.GetDirectoryName(entity.State.SourcePaths[0].FullFilePath)
             ?? entity.State.SourcePaths[0].Path;
         sourcePath = sourcePath?.Replace('\\', '/') ?? throw new InvalidOperationException("Source path cannot be null or empty.");
+
+        // Show the NetApp source as the full path including the case root folder, so it lines up with
+        // the full file paths above (the UI lists files relative to it) and matches how the NetApp
+        // destination is shown for the reverse direction. The source root in state is relative to the
+        // case root, so add the root back for display.
+        if (!string.IsNullOrEmpty(netappRootFolderPath))
+        {
+            sourcePath = PrependNetappRootFolder(netappRootFolderPath, sourcePath);
+        }
 
         var deletionErrors = new List<FileTransferError>();
 
@@ -100,5 +131,26 @@ public class UpdateActivityLog(IActivityLogService activityLogService, ILogger<U
             userName: payload.UserName,
             details: fileTransferDetails.SerializeToJsonDocument(_logger)
         );
+    }
+
+    private static string PrependNetappRootFolder(string netappRootFolderPath, string sourcePath)
+    {
+        var root = netappRootFolderPath.Replace('\\', '/').TrimEnd('/');
+        var relative = sourcePath.TrimStart('/');
+
+        if (string.IsNullOrEmpty(relative))
+        {
+            return root;
+        }
+
+        // The source root was not stripped (for example, case metadata was missing when the files
+        // were listed), so it already includes the root. Do not add it a second time.
+        if (relative.Equals(root, StringComparison.OrdinalIgnoreCase)
+            || relative.StartsWith(root + "/", StringComparison.OrdinalIgnoreCase))
+        {
+            return relative;
+        }
+
+        return $"{root}/{relative}";
     }
 }


### PR DESCRIPTION
For `NetApp to Egress` transfers the activity log showed the source with the case's NetApp root folder stripped (e.g. "`preview`"), while the same folder shown as a destination kept it in full ("`LCCDemo2 > preview`"). It also left the file list a level too deep, because the file paths keep the root but the source did not.

`UpdateActivityLog` now prepends the NetApp root folder back onto the source for `NetApp to Egress`, so it matches the destination and the file list resolves relative to it. File paths and transfer state are untouched. The metadata lookup is guarded and falls back to the relative source if it fails, so it can't stop the log being written.

Adds unit tests for the full path, the double-root guard, a missing NetApp folder path, and a failing metadata lookup.

# PR checklist

Tick what applies before you raise. Delete anything that doesn't.

## Correctness
- [x] Does what the ticket asks for
- [x] Handles the edge cases (empty, null, zero, large inputs), not just the happy path
- [x] Errors are handled, not swallowed
- [x] New logic has tests, including the failure cases
- [x] Tests assert something real, not just run the code

## Keeping it simple
- [x] Doesn't rebuild something that already exists in the codebase
- [x] No more complex or slower than it needs to be
- [x] No leftover debug logging or commented-out code

## Easy to miss (a green pipeline won't flag these)
- [x] One logical change, not a pile of unrelated stuff