### PR TITLE
FCT2- 20332: Transfer material changes for new UI

### DIFF
--- a/e2e/pw/.env.template
+++ b/e2e/pw/.env.template
@@ -30,6 +30,12 @@ TEST_FILE_SIZE_MB=10               # Test file size
 TEST_FILE_COUNT=1                  # Number of files to upload
 LARGE_TEST_FILE_SIZE_MB=50         # Large test file size
 
+# Which Transfer Materials screen to drive: true = new (v1), false = old.
+# Must match what the environment renders for E2E_AD_USER; it does not enable
+# the SPA flag (needs VITE_FEATURE_FLAG_TRANSFER_MATERIALS_V1=true at build +
+# VITE_PRIVATE_BETA_FEATURE_USER_GROUP2 membership). See README.
+TRANSFER_MATERIALS_V1=false
+
 # Default mode — required for npm run e2e:existing-case
 # By convention the Egress workspace and the connected NetApp folder both
 # use the name `existingCaseAutomation`. Provision the pair once per

--- a/e2e/pw/README.md
+++ b/e2e/pw/README.md
@@ -214,15 +214,19 @@ Selects which screen the specs drive: `false` (default) = old screen, `true` =
 redesigned screen. It is a **selector only** — it must match what the
 environment renders for `E2E_AD_USER`, or the specs drive the wrong screen and fail.
 
-Specs never branch on this flag directly. They build the Transfer Materials
-page object via `getTransferMaterialsTab(page)`, which reads the switch and
-returns either `TransferMaterialsTab` (old screen) or `TransferMaterialsTabV1`
-(new screen). Both implement the shared `TransferMaterialsTabApi` contract, so
-a spec depends only on that surface and stays screen-agnostic. The new screen
-adds a destination-tree step after Copy/Move — driven by `TransferDestinationPage`
-— because it has no confirm modal. A spec that must diverge (e.g.
-`netapp-to-egress-copy-default`) reads `loadEnvConfig().transferMaterialsV1`
-explicitly rather than referencing screen-specific selectors.
+Specs stay screen-agnostic by building the Transfer Materials page object via
+`getTransferMaterialsTab(page)`, which reads the switch and returns either
+`TransferMaterialsTab` (old screen) or `TransferMaterialsTabV1` (new screen).
+Both implement the shared `TransferMaterialsTabApi` contract, so a spec depends
+only on that surface — no screen-specific selectors.
+
+The one place the flow genuinely differs is the NetApp → Egress destination:
+the old screen navigates the second Egress panel and confirms in a modal, while
+the new screen has no second panel and instead navigates a destination tree
+(`TransferDestinationPage`). The two specs that do this —
+`netapp-to-egress-copy.spec.ts` and `netapp-to-egress-copy-default.spec.ts` —
+branch on `loadEnvConfig().transferMaterialsV1` to pick the right path, rather
+than referencing screen-specific selectors directly.
 
 For a real Azure AD user the new screen renders only when **both** hold:
 

--- a/e2e/pw/README.md
+++ b/e2e/pw/README.md
@@ -13,20 +13,31 @@ Tests run in two modes:
 
 ### Test Matrix
 
-| Test | Files | Default Mode | Register Case Mode |
-|------|-------|--------------|--------------------|
-| Egress to NetApp Copy | 10MB x 1 | ✓ | ✓ |
-| Egress to NetApp Copy - Large | 50MB x 1 | ✓ | ✓ |
-| Egress to NetApp Copy - Multifile | 10MB x 3 | -- | ✓ |
-| Egress to NetApp Move | 10MB x 1 | ✓ | ✓ |
-| NetApp to Egress Copy | 10MB x 1 | ✓ (uses seeded fixture) | ✓ (sort + row 0) |
-| Full Flow (login, search, connect) | 10MB x 1 | -- | ✓ |
+The two modes use different file sizes for the same logical test — default
+mode stays small for fast iteration, register-case mode exercises larger
+transfers. The Default / Register columns show each mode's size (`--` = not
+run in that mode).
+
+| Test | Default Mode | Register Case Mode |
+|------|--------------|--------------------|
+| Egress to NetApp Copy | ✓ 10MB x 1 | ✓ 100MB x 1 |
+| Egress to NetApp Copy - Large | ✓ 50MB x 1 | ✓ 200MB x 1 |
+| Egress to NetApp Copy - Multifile | -- | ✓ 10MB x 3 |
+| Egress to NetApp Move | ✓ 10MB x 1 | ✓ 100MB x 1 |
+| NetApp to Egress Copy | ✓ 10MB x 1 (uses seeded fixture) | ✓ 100MB x 1 (sort + row 0) |
+| Full Flow (login, search, connect) | -- | ✓ 100MB x 1 |
+
+Default-mode sizes come from `TEST_FILE_SIZE_MB` (10) and
+`LARGE_TEST_FILE_SIZE_MB` (50); register-case sizes are set per spec via
+`test.use({ testOptions: { fileSizeMb, fileCount } })`.
 
 NetApp -> Egress Move is descoped — the product UI doesn't expose a Move
-button in that direction (`EgressFolderContainer.tsx` has no Move
-references; only `NetAppFolderContainer.tsx` does, gated on the
+button in that direction on either screen. Old screen: `EgressFolderContainer.tsx`
+has no Move references; only `NetAppFolderContainer.tsx` does, gated on the
 `transferMove` feature flag, which renders Move in the Egress -> NetApp
-direction only).
+direction only. New screen (`transfer-materials-v1/`): `TransferControls.tsx`
+renders the `Move selected` button only when the source is Egress. Either way,
+Move is available in the Egress -> NetApp direction only.
 
 ## Project Structure
 
@@ -48,6 +59,12 @@ e2e/pw/
     register-case-state.ts            # Shared state file paths for the setup project
     types.ts                          # TypeScript type definitions
   pages/                              # Page Object Models
+    getTransferMaterialsTab.ts        # Picks the screen POM from TRANSFER_MATERIALS_V1
+    TransferMaterialsTabApi.ts        # Screen-agnostic Transfer Materials contract
+    TransferMaterialsTab.ts           # Old-screen implementation
+    TransferMaterialsTabV1.ts         # New-screen (v1) implementation
+    TransferDestinationPage.ts        # New-screen destination-tree page (pick folder + confirm)
+    ...                               # CaseSearch, SearchResults, CaseManagement, ActivityLog, login/connect POMs
   tests/
     register-case.setup.ts            # Setup project: register + connect once per run
     register-case.teardown.ts         # 24h workspace sweep, run after register-case-tests
@@ -189,6 +206,37 @@ standard auth set.
 | `LCC_API_BASE_URL` | LCC backend URL — used by NetApp file teardown + disassociate | Default mode (recommended); register-case (recommended) |
 | `NETAPP_OPERATION_NAME` | Connected NetApp folder for default mode | Default mode (recommended) |
 | `LCC_API_CLIENT_SECRET` | Secret for `LCC_API_CLIENT_ID` | Register-case (recommended) |
+| `TRANSFER_MATERIALS_V1` | Which Transfer Materials screen to drive (see below) | No (default: false) |
+
+## Transfer Materials screen: `TRANSFER_MATERIALS_V1`
+
+Selects which screen the specs drive: `false` (default) = old screen, `true` =
+redesigned screen. It is a **selector only** — it must match what the
+environment renders for `E2E_AD_USER`, or the specs drive the wrong screen and fail.
+
+Specs never branch on this flag directly. They build the Transfer Materials
+page object via `getTransferMaterialsTab(page)`, which reads the switch and
+returns either `TransferMaterialsTab` (old screen) or `TransferMaterialsTabV1`
+(new screen). Both implement the shared `TransferMaterialsTabApi` contract, so
+a spec depends only on that surface and stays screen-agnostic. The new screen
+adds a destination-tree step after Copy/Move — driven by `TransferDestinationPage`
+— because it has no confirm modal. A spec that must diverge (e.g.
+`netapp-to-egress-copy-default`) reads `loadEnvConfig().transferMaterialsV1`
+explicitly rather than referencing screen-specific selectors.
+
+For a real Azure AD user the new screen renders only when **both** hold:
+
+1. The deployed SPA at `BASE_URL` was built with
+   `VITE_FEATURE_FLAG_TRANSFER_MATERIALS_V1=true` (baked in at build time via the
+   env's Azure DevOps variable group — not in this repo, not runtime-toggleable).
+2. `E2E_AD_USER` is a member of the Azure AD group set as that environment's
+   `VITE_PRIVATE_BETA_FEATURE_USER_GROUP2`.
+
+The `?transfer-materials-v1=true` query override does **not** apply to
+`E2E_AD_USER` — only to the mock-auth user `dev_user@example.org` in ui-spa's own
+mocked integration tests. Neither (1) nor (2) is readable from this repo; confirm
+by signing in as `E2E_AD_USER` on the target environment and checking the tab,
+then set `TRANSFER_MATERIALS_V1` to match.
 
 ## Environment Profiles
 

--- a/e2e/pw/helpers/env-config.ts
+++ b/e2e/pw/helpers/env-config.ts
@@ -23,6 +23,15 @@ function positiveIntEnv(name: string, defaultValue: string): number {
   return parsed;
 }
 
+function boolEnv(name: string, defaultValue: string): boolean {
+  const raw = optionalEnv(name, defaultValue).trim().toLowerCase();
+  if (["true", "1", "yes", "on"].includes(raw)) return true;
+  if (["false", "0", "no", "off", ""].includes(raw)) return false;
+  throw new Error(
+    `Invalid ${name}: expected a boolean (true/false), got "${raw}"`,
+  );
+}
+
 export function loadEnvConfig() {
   return {
     baseUrl: requireEnv("BASE_URL"),
@@ -56,6 +65,12 @@ export function loadEnvConfig() {
     testFileSizeMb: positiveIntEnv("TEST_FILE_SIZE_MB", "10"),
     testFileCount: positiveIntEnv("TEST_FILE_COUNT", "1"),
     largeTestFileSizeMb: positiveIntEnv("LARGE_TEST_FILE_SIZE_MB", "50"),
+
+    // Selects which Transfer Materials screen the suite drives. `true` when
+    // the target environment renders the redesigned (v1) screen for the E2E
+    // user; `false` drives the old screen. This is a which-screen-to-expect
+    // switch only — it does not enable the SPA feature flag (see README).
+    transferMaterialsV1: boolEnv("TRANSFER_MATERIALS_V1", "false"),
 
     defaultWorkspaceId: process.env.DEFAULT_WORKSPACE_ID || "",
     defaultWorkspaceName: process.env.DEFAULT_WORKSPACE_NAME || "",

--- a/e2e/pw/helpers/env-config.ts
+++ b/e2e/pw/helpers/env-config.ts
@@ -66,10 +66,9 @@ export function loadEnvConfig() {
     testFileCount: positiveIntEnv("TEST_FILE_COUNT", "1"),
     largeTestFileSizeMb: positiveIntEnv("LARGE_TEST_FILE_SIZE_MB", "50"),
 
-    // Selects which Transfer Materials screen the suite drives. `true` when
-    // the target environment renders the redesigned (v1) screen for the E2E
-    // user; `false` drives the old screen. This is a which-screen-to-expect
-    // switch only — it does not enable the SPA feature flag (see README).
+    // Which Transfer Materials screen to drive: `true` = new (v1), `false` =
+    // old. Must match what the environment renders for the E2E user; it does
+    // not enable the SPA feature flag (see README).
     transferMaterialsV1: boolEnv("TRANSFER_MATERIALS_V1", "false"),
 
     defaultWorkspaceId: process.env.DEFAULT_WORKSPACE_ID || "",

--- a/e2e/pw/helpers/env-config.ts
+++ b/e2e/pw/helpers/env-config.ts
@@ -49,7 +49,7 @@ export function loadEnvConfig() {
     e2eAdPassword: requireEnv("E2E_AD_PASSWORD"),
     cmsUsername: requireEnv("CMS_USERNAME"),
     cmsPassword: requireEnv("CMS_PASSWORD"),
-    // DDEI base url and function key for the register-case endpoint. 
+    // DDEI base url and function key for the register-case endpoint.
     // The register-case path validates presence at the callsite and
     // throws a clear error if missing.
     ddeiBaseUrl: process.env.DDEI_BASE_URL || "",

--- a/e2e/pw/pages/BaseTransferMaterialsTab.ts
+++ b/e2e/pw/pages/BaseTransferMaterialsTab.ts
@@ -1,0 +1,110 @@
+import { Page } from "@playwright/test";
+
+/**
+ * Shared Egress-side and common helpers for both Transfer Materials page
+ * objects. The Egress table, folder navigation, file-indexing wait and the
+ * NetApp date-sort are identical across the old and new screens (bar the NetApp
+ * table's test id), so they live here; screen-specific behaviour stays in the
+ * `TransferMaterialsTab` / `TransferMaterialsTabV1` subclasses.
+ */
+export abstract class BaseTransferMaterialsTab {
+  protected readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  /** Wait for the Egress / NetApp panel's folder listing to finish loading. */
+  abstract waitForEgressFiles(): Promise<void>;
+  abstract waitForNetAppFiles(): Promise<void>;
+
+  /** Test id of the NetApp / shared-drive table wrapper on this screen. */
+  protected abstract readonly netAppWrapperTestId: string;
+
+  async selectAllEgressFiles(): Promise<void> {
+    await this.page
+      .getByTestId("egress-table-wrapper")
+      .getByLabel("Select folders and files")
+      .check();
+  }
+
+  async selectEgressFileByName(fileName: string): Promise<void> {
+    const row = this.page
+      .getByTestId("egress-table-wrapper")
+      .locator("tbody tr", { hasText: fileName });
+    const checkbox = row.locator('input[type="checkbox"]');
+    await checkbox.scrollIntoViewIfNeeded();
+    await checkbox.check();
+  }
+
+  async navigateToFolder(folderName: string): Promise<void> {
+    await this.page.getByRole("button", { name: folderName }).click();
+  }
+
+  /**
+   * Sort the NetApp panel by last-modified date descending (two header clicks).
+   * Best-effort: the sort doesn't reliably toggle to descending, so a flaky/slow
+   * header is tolerated and the panel is left unsorted.
+   */
+  async sortNetAppByDateDescending(): Promise<void> {
+    const header = this.page
+      .getByTestId(this.netAppWrapperTestId)
+      .getByRole("button", { name: "Last modified date" });
+    try {
+      await header.click({ timeout: 20_000 });
+      await this.waitForNetAppFiles();
+      await header.click({ timeout: 20_000 });
+      await this.waitForNetAppFiles();
+    } catch {
+      console.log(
+        "  [sortNetAppByDateDescending] date sort skipped (best-effort)",
+      );
+    }
+  }
+
+  /**
+   * Wait for a file to appear in the Egress panel. Egress fetches a folder's
+   * list once and doesn't auto-refresh, so each retry reloads (busting the
+   * React Query cache) and re-navigates the folder path.
+   */
+  async waitForEgressFileByName(
+    fileName: string,
+    folderPath: string[],
+    timeout: number = 300_000,
+  ): Promise<void> {
+    const egressTable = this.page.getByTestId("egress-table-wrapper");
+    const start = Date.now();
+
+    const fileVisible = async () =>
+      (await egressTable.locator("tbody tr", { hasText: fileName }).count()) >
+      0;
+
+    if (await fileVisible()) return;
+
+    while (Date.now() - start < timeout) {
+      console.log(`  Waiting for ${fileName} to be indexed; refreshing...`);
+      await this.page.waitForTimeout(5_000);
+      await this.page.reload();
+      await this.waitForEgressFiles();
+      for (const folder of folderPath) {
+        await this.navigateToFolder(folder);
+        await this.waitForEgressFiles();
+      }
+      if (await fileVisible()) return;
+    }
+    throw new Error(
+      `Timed out waiting for ${fileName} to appear in Egress panel (timeout: ${timeout}ms)`,
+    );
+  }
+
+  /** Standard "fixture missing" error for the NetApp / shared-drive panel. */
+  protected fixtureMissingError(fileName: string, panelName: string): Error {
+    return new Error(
+      `Required NetApp fixture '${fileName}' not found in the ${panelName}.\n` +
+        `  Seed it via:\n` +
+        `    bash:       RUN_SEED=1 npx playwright test --project=seed-netapp-fixture\n` +
+        `    powershell: $env:RUN_SEED=1; npx playwright test --project=seed-netapp-fixture\n` +
+        `  See README "Required NetApp fixture" for details.`,
+    );
+  }
+}

--- a/e2e/pw/pages/TransferDestinationPage.ts
+++ b/e2e/pw/pages/TransferDestinationPage.ts
@@ -38,13 +38,22 @@ export class TransferDestinationPage {
     });
   }
 
-  /** Expand a folder node (no-op if already expanded). */
+  /**
+   * Expand a folder node. Waits for the node to render first — children load via
+   * an async fetch, so a bare `count()` can snapshot 0 and silently skip before
+   * the node (or a parent's children) has arrived. Once the node is present,
+   * only click when it's collapsed: the toggle reads "plus" when collapsed and
+   * "minus" when already expanded, so an already-expanded node is a no-op.
+   */
   async expandFolder(folderName: string): Promise<void> {
-    const toggle = this.folderNode(folderName)
+    const node = this.folderNode(folderName);
+    await node.waitFor({ state: "visible", timeout: 30_000 });
+    const toggle = node
       .locator("xpath=..")
-      .getByRole("button", { name: "plus" });
-    if ((await toggle.count()) > 0) {
-      await toggle.first().click();
+      .getByRole("button", { name: "plus" })
+      .first();
+    if (await toggle.isVisible().catch(() => false)) {
+      await toggle.click();
     }
   }
 
@@ -81,10 +90,6 @@ export class TransferDestinationPage {
     await this.page
       .getByRole("button", { name: new RegExp(`^${action} to `) })
       .click();
-  }
-
-  async cancel(): Promise<void> {
-    await this.page.getByRole("button", { name: "Cancel" }).click();
   }
 
   /** Expand ancestors, select the final folder, and confirm. `folderPath` runs

--- a/e2e/pw/pages/TransferDestinationPage.ts
+++ b/e2e/pw/pages/TransferDestinationPage.ts
@@ -1,24 +1,15 @@
 import { Page, Locator } from "@playwright/test";
 
 /**
- * New-screen destination page (`/case/:caseId/case-management/transfer-destination-page`).
+ * New-screen destination page (`.../case-management/transfer-destination-page`),
+ * reached after "Copy selected" / "Move selected" instead of a confirm modal.
+ * Renders a folder tree; you expand nodes, pick a target, then confirm with a
+ * "<Copy|Move> to <folder>" button.
  *
- * After "Copy selected" / "Move selected" the new screen navigates here instead
- * of showing a confirm modal. The page renders a folder tree (TransferWidget /
- * TreeViewComponent); you expand nodes, pick a target folder, then confirm with
- * a "<Copy|Move> to <folder>" button.
- *
- * Selectors confirmed against the rendered DOM:
- *   - tree:            role="tree", accessible name "Folders"
- *   - folder node:     a <button> whose accessible name is the folder name
- *                      *lowercased* (aria-label = node.name.toLowerCase())
- *   - expand toggle:   sibling <button> with aria-label "plus" (collapsed) /
- *                      "minus" (expanded)
- *   - confirm button:  "<Copy|Move> to <folder>" (folder name in original case);
- *                      reads just "Copy"/"Move" and is disabled until a node is
- *                      selected
- *   - cancel:          <button> "Cancel"
- *   - initial loader:  data-testid "destination-loader"
+ * DOM: tree = role "tree" name "Folders"; folder node = a <button> whose
+ * aria-label is the folder name *lowercased*; expand toggle = sibling button
+ * aria-label "plus"/"minus"; confirm = "<Copy|Move> to <folder>" (disabled
+ * until a node is selected); initial loader = testid "destination-loader".
  */
 export class TransferDestinationPage {
   private readonly page: Page;
@@ -29,7 +20,7 @@ export class TransferDestinationPage {
     this.tree = page.getByRole("tree", { name: "Folders" });
   }
 
-  /** Wait until the folder tree has loaded (initial folder fetch complete). */
+  /** Wait for the folder tree to finish its initial load. */
   async waitForLoaded(timeout: number = 60_000): Promise<void> {
     await this.page
       .getByTestId("destination-loader")
@@ -38,11 +29,8 @@ export class TransferDestinationPage {
     await this.tree.waitFor({ state: "visible", timeout });
   }
 
-  /**
-   * The folder node button. Its accessible name is the folder name lowercased
-   * (aria-label), so match on the lowercased name exactly to avoid substring
-   * collisions between sibling folders.
-   */
+  /** Folder node button — aria-label is the lowercased name; match exactly to
+   * avoid sibling substring collisions. */
   private folderNode(folderName: string): Locator {
     return this.tree.getByRole("button", {
       name: folderName.toLowerCase(),
@@ -50,9 +38,8 @@ export class TransferDestinationPage {
     });
   }
 
-  /** Expand a folder node (no-op if it is already expanded). */
+  /** Expand a folder node (no-op if already expanded). */
   async expandFolder(folderName: string): Promise<void> {
-    // The expand toggle is a sibling button inside the same node container.
     const toggle = this.folderNode(folderName)
       .locator("xpath=..")
       .getByRole("button", { name: "plus" });
@@ -67,11 +54,10 @@ export class TransferDestinationPage {
   }
 
   /**
-   * Select the first selectable (non-disabled) folder in the tree and return its
-   * accessible name. For Egress→NetApp the root ("Shared drive: …") is selectable
-   * and is the connected folder root; for NetApp→Egress the root ("Egress : …")
-   * is disabled, so the first enabled node is its first child folder (the root is
-   * expanded on load). Handy when the target is just "the connected root folder".
+   * Select the first enabled folder and return its label. For Egress→NetApp the
+   * root is selectable (the connected folder); for NetApp→Egress the root is
+   * disabled so this picks its first child. Use when the target is just "the
+   * connected root".
    */
   async selectFirstSelectableFolder(): Promise<string> {
     const folders = this.tree.locator(
@@ -89,11 +75,8 @@ export class TransferDestinationPage {
     throw new Error("No selectable folder found in the destination tree");
   }
 
-  /**
-   * Click the confirm button. Once a folder is selected the button reads
-   * "<Copy|Move> to <folder>"; it is the only such button on the page, so the
-   * "<action> to " prefix identifies it without needing the folder name.
-   */
+  /** Click confirm. Once a folder is selected the button reads
+   * "<Copy|Move> to <folder>" and is the only such button. */
   async confirm(action: "Copy" | "Move"): Promise<void> {
     await this.page
       .getByRole("button", { name: new RegExp(`^${action} to `) })
@@ -104,11 +87,8 @@ export class TransferDestinationPage {
     await this.page.getByRole("button", { name: "Cancel" }).click();
   }
 
-  /**
-   * Convenience: open to a target folder and confirm. `folderPath` is the
-   * sequence of folder names from a tree root down to the target; ancestors are
-   * expanded, the final folder is selected, then the transfer is confirmed.
-   */
+  /** Expand ancestors, select the final folder, and confirm. `folderPath` runs
+   * from a tree root down to the target. */
   async chooseFolder(
     action: "Copy" | "Move",
     folderPath: string[],

--- a/e2e/pw/pages/TransferDestinationPage.ts
+++ b/e2e/pw/pages/TransferDestinationPage.ts
@@ -1,0 +1,124 @@
+import { Page, Locator } from "@playwright/test";
+
+/**
+ * New-screen destination page (`/case/:caseId/case-management/transfer-destination-page`).
+ *
+ * After "Copy selected" / "Move selected" the new screen navigates here instead
+ * of showing a confirm modal. The page renders a folder tree (TransferWidget /
+ * TreeViewComponent); you expand nodes, pick a target folder, then confirm with
+ * a "<Copy|Move> to <folder>" button.
+ *
+ * Selectors confirmed against the rendered DOM:
+ *   - tree:            role="tree", accessible name "Folders"
+ *   - folder node:     a <button> whose accessible name is the folder name
+ *                      *lowercased* (aria-label = node.name.toLowerCase())
+ *   - expand toggle:   sibling <button> with aria-label "plus" (collapsed) /
+ *                      "minus" (expanded)
+ *   - confirm button:  "<Copy|Move> to <folder>" (folder name in original case);
+ *                      reads just "Copy"/"Move" and is disabled until a node is
+ *                      selected
+ *   - cancel:          <button> "Cancel"
+ *   - initial loader:  data-testid "destination-loader"
+ */
+export class TransferDestinationPage {
+  private readonly page: Page;
+  private readonly tree: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.tree = page.getByRole("tree", { name: "Folders" });
+  }
+
+  /** Wait until the folder tree has loaded (initial folder fetch complete). */
+  async waitForLoaded(timeout: number = 60_000): Promise<void> {
+    await this.page
+      .getByTestId("destination-loader")
+      .waitFor({ state: "hidden", timeout })
+      .catch(() => {});
+    await this.tree.waitFor({ state: "visible", timeout });
+  }
+
+  /**
+   * The folder node button. Its accessible name is the folder name lowercased
+   * (aria-label), so match on the lowercased name exactly to avoid substring
+   * collisions between sibling folders.
+   */
+  private folderNode(folderName: string): Locator {
+    return this.tree.getByRole("button", {
+      name: folderName.toLowerCase(),
+      exact: true,
+    });
+  }
+
+  /** Expand a folder node (no-op if it is already expanded). */
+  async expandFolder(folderName: string): Promise<void> {
+    // The expand toggle is a sibling button inside the same node container.
+    const toggle = this.folderNode(folderName)
+      .locator("xpath=..")
+      .getByRole("button", { name: "plus" });
+    if ((await toggle.count()) > 0) {
+      await toggle.first().click();
+    }
+  }
+
+  /** Select (highlight) a folder node as the transfer target. */
+  async selectFolder(folderName: string): Promise<void> {
+    await this.folderNode(folderName).click();
+  }
+
+  /**
+   * Select the first selectable (non-disabled) folder in the tree and return its
+   * accessible name. For Egress→NetApp the root ("Shared drive: …") is selectable
+   * and is the connected folder root; for NetApp→Egress the root ("Egress : …")
+   * is disabled, so the first enabled node is its first child folder (the root is
+   * expanded on load). Handy when the target is just "the connected root folder".
+   */
+  async selectFirstSelectableFolder(): Promise<string> {
+    const folders = this.tree.locator(
+      'button[aria-label]:not([aria-label="plus"]):not([aria-label="minus"])',
+    );
+    const count = await folders.count();
+    for (let i = 0; i < count; i++) {
+      const btn = folders.nth(i);
+      if (await btn.isEnabled()) {
+        const label = (await btn.getAttribute("aria-label")) ?? "";
+        await btn.click();
+        return label;
+      }
+    }
+    throw new Error("No selectable folder found in the destination tree");
+  }
+
+  /**
+   * Click the confirm button. Once a folder is selected the button reads
+   * "<Copy|Move> to <folder>"; it is the only such button on the page, so the
+   * "<action> to " prefix identifies it without needing the folder name.
+   */
+  async confirm(action: "Copy" | "Move"): Promise<void> {
+    await this.page
+      .getByRole("button", { name: new RegExp(`^${action} to `) })
+      .click();
+  }
+
+  async cancel(): Promise<void> {
+    await this.page.getByRole("button", { name: "Cancel" }).click();
+  }
+
+  /**
+   * Convenience: open to a target folder and confirm. `folderPath` is the
+   * sequence of folder names from a tree root down to the target; ancestors are
+   * expanded, the final folder is selected, then the transfer is confirmed.
+   */
+  async chooseFolder(
+    action: "Copy" | "Move",
+    folderPath: string[],
+  ): Promise<void> {
+    await this.waitForLoaded();
+    for (const ancestor of folderPath.slice(0, -1)) {
+      await this.expandFolder(ancestor);
+    }
+    const target = folderPath[folderPath.length - 1];
+    await this.selectFolder(target);
+    await this.confirm(action);
+  }
+}

--- a/e2e/pw/pages/TransferMaterialsTab.ts
+++ b/e2e/pw/pages/TransferMaterialsTab.ts
@@ -70,7 +70,10 @@ export class TransferMaterialsTab
       .click();
   }
 
-  async confirmTransfer() {
+  async confirmTransfer(_action: "Copy" | "Move") {
+    // The old-screen confirm modal is action-agnostic (the "I want to
+    // copy/move" radio matches either), so `_action` is accepted only to
+    // satisfy the shared contract.
     const modal = this.page.getByTestId("div-modal");
     await modal.waitFor({ state: "visible", timeout: 30000 });
     await modal.getByLabel(/I want to (copy|move)/).click();

--- a/e2e/pw/pages/TransferMaterialsTab.ts
+++ b/e2e/pw/pages/TransferMaterialsTab.ts
@@ -221,16 +221,22 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
   }
 
   /**
-   * The old screen keeps the transfer view mounted through transfer errors
-   * (the error is shown inline, not as a separate route), so there is no
-   * error page to leave. No-op — present to satisfy the shared contract.
+   * Both screens navigate to a shared full-page transfer error (no tablist) on a
+   * failed or duplicate-rejected transfer. If on it, follow "Back" to case
+   * management so the tab can be re-entered. Keyed off the error heading (the
+   * old screen detects by text, not route). No-op otherwise.
    */
-  async dismissTransferErrorIfPresent(): Promise<void> {}
+  async dismissTransferErrorIfPresent(): Promise<void> {
+    const errorHeading = this.page.getByRole("heading", {
+      name: "There is a problem transferring files",
+    });
+    if (!(await errorHeading.isVisible().catch(() => false))) return;
+    await this.page.getByRole("link", { name: "Back", exact: true }).click();
+  }
 
   /**
-   * Verify a file landed in the NetApp panel. The old screen shows both
-   * panels side by side, so the NetApp table is already visible — assert
-   * it contains the file in place (no source switch needed).
+   * Verify a file landed in the NetApp panel. Both panels are visible on the old
+   * screen, so assert the NetApp table contains the file in place.
    */
   async verifyNetAppContainsFile(
     fileName: string,

--- a/e2e/pw/pages/TransferMaterialsTab.ts
+++ b/e2e/pw/pages/TransferMaterialsTab.ts
@@ -1,6 +1,7 @@
 import { Page, expect } from "@playwright/test";
+import { TransferMaterialsTabApi } from "./TransferMaterialsTabApi";
 
-export class TransferMaterialsTab {
+export class TransferMaterialsTab implements TransferMaterialsTabApi {
   private readonly page: Page;
 
   constructor(page: Page) {
@@ -47,6 +48,25 @@ export class TransferMaterialsTab {
       .locator("tbody tr");
     for (const index of indices) {
       await rows.nth(index).locator('input[type="checkbox"]').check();
+    }
+  }
+
+  /**
+   * Sort the NetApp panel by last-modified date descending (two header clicks).
+   * The NetApp panel's date sort doesn't reliably toggle to descending, so this
+   * mirrors the click-twice approach specs relied on inline.
+   */
+  async sortNetAppByDateDescending() {
+    const header = this.page
+      .getByTestId("netapp-table-wrapper")
+      .getByRole("button", { name: "Last modified date" });
+    try {
+      await header.click({ timeout: 20_000 });
+      await this.waitForNetAppFiles();
+      await header.click({ timeout: 20_000 });
+      await this.waitForNetAppFiles();
+    } catch {
+      console.log("  [sortNetAppByDateDescending] date sort skipped (best-effort)");
     }
   }
 
@@ -198,6 +218,27 @@ export class TransferMaterialsTab {
     throw new Error(
       `Timed out waiting for ${fileName} to be selectable in NetApp panel (timeout: ${timeout}ms, last row count: ${lastRowCount})`
     );
+  }
+
+  /**
+   * The old screen keeps the transfer view mounted through transfer errors
+   * (the error is shown inline, not as a separate route), so there is no
+   * error page to leave. No-op — present to satisfy the shared contract.
+   */
+  async dismissTransferErrorIfPresent(): Promise<void> {}
+
+  /**
+   * Verify a file landed in the NetApp panel. The old screen shows both
+   * panels side by side, so the NetApp table is already visible — assert
+   * it contains the file in place (no source switch needed).
+   */
+  async verifyNetAppContainsFile(
+    fileName: string,
+    timeout: number = 30_000,
+  ): Promise<void> {
+    const netappTable = this.page.getByTestId("netapp-table-wrapper");
+    await expect(netappTable).toBeVisible({ timeout });
+    await expect(netappTable).toContainText(fileName, { timeout });
   }
 
   async navigateToFolder(folderName: string) {

--- a/e2e/pw/pages/TransferMaterialsTab.ts
+++ b/e2e/pw/pages/TransferMaterialsTab.ts
@@ -66,7 +66,9 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
       await header.click({ timeout: 20_000 });
       await this.waitForNetAppFiles();
     } catch {
-      console.log("  [sortNetAppByDateDescending] date sort skipped (best-effort)");
+      console.log(
+        "  [sortNetAppByDateDescending] date sort skipped (best-effort)",
+      );
     }
   }
 
@@ -99,8 +101,12 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
   }
 
   async waitForTransferComplete(timeout: number = 300_000) {
-    const successBanner = this.page.getByTestId("transfer-success-notification-banner");
-    const errorHeading = this.page.locator('text="There is a problem transferring files"');
+    const successBanner = this.page.getByTestId(
+      "transfer-success-notification-banner",
+    );
+    const errorHeading = this.page.locator(
+      'text="There is a problem transferring files"',
+    );
 
     // Wait for either success banner or error page to appear
     await Promise.race([
@@ -119,9 +125,7 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
   }
 
   async getTransferProgress(): Promise<string> {
-    return await this.page
-      .getByTestId("transfer-progress-metrics")
-      .innerText();
+    return await this.page.getByTestId("transfer-progress-metrics").innerText();
   }
 
   async selectEgressFileByName(fileName: string) {
@@ -165,7 +169,7 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
           `  Seed it via:\n` +
           `    bash:       RUN_SEED=1 npx playwright test --project=seed-netapp-fixture\n` +
           `    powershell: $env:RUN_SEED=1; npx playwright test --project=seed-netapp-fixture\n` +
-          `  See README "Required NetApp fixture" for details.`
+          `  See README "Required NetApp fixture" for details.`,
       );
     }
     const checkbox = row.locator('input[type="checkbox"]').first();
@@ -182,7 +186,7 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
    */
   async selectNetAppFileByNameWithScroll(
     fileName: string,
-    timeout: number = 180_000
+    timeout: number = 180_000,
   ) {
     const netappTable = this.page.getByTestId("netapp-table-wrapper");
     const fileRow = netappTable.locator("tbody tr", { hasText: fileName });
@@ -216,7 +220,7 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
       await this.page.waitForTimeout(1_500);
     }
     throw new Error(
-      `Timed out waiting for ${fileName} to be selectable in NetApp panel (timeout: ${timeout}ms, last row count: ${lastRowCount})`
+      `Timed out waiting for ${fileName} to be selectable in NetApp panel (timeout: ${timeout}ms, last row count: ${lastRowCount})`,
     );
   }
 
@@ -264,15 +268,14 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
   async waitForEgressFileByName(
     fileName: string,
     folderPath: string[],
-    timeout: number = 300_000
+    timeout: number = 300_000,
   ) {
     const egressTable = this.page.getByTestId("egress-table-wrapper");
     const start = Date.now();
 
     const fileVisible = async () =>
-      (await egressTable
-        .locator("tbody tr", { hasText: fileName })
-        .count()) > 0;
+      (await egressTable.locator("tbody tr", { hasText: fileName }).count()) >
+      0;
 
     if (await fileVisible()) return;
 
@@ -288,20 +291,28 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
       if (await fileVisible()) return;
     }
     throw new Error(
-      `Timed out waiting for ${fileName} to appear in Egress panel (timeout: ${timeout}ms)`
+      `Timed out waiting for ${fileName} to appear in Egress panel (timeout: ${timeout}ms)`,
     );
   }
 
   /** Wait until at least `expectedCount` file rows appear in the Egress panel folder, refreshing periodically. */
-  async waitForFileCount(expectedCount: number, folderName: string, timeout: number = 120_000) {
-    const egressTable = this.page.getByTestId("egress-table-wrapper").locator("table");
+  async waitForFileCount(
+    expectedCount: number,
+    folderName: string,
+    timeout: number = 120_000,
+  ) {
+    const egressTable = this.page
+      .getByTestId("egress-table-wrapper")
+      .locator("table");
     const start = Date.now();
     // Check current count first (already navigated into folder)
     let rows = await egressTable.locator("tbody tr").all();
     if (rows.length >= expectedCount) return;
 
     while (Date.now() - start < timeout) {
-      console.log(`  Waiting for files: ${rows.length}/${expectedCount} visible, refreshing...`);
+      console.log(
+        `  Waiting for files: ${rows.length}/${expectedCount} visible, refreshing...`,
+      );
       await this.page.waitForTimeout(5_000);
       // Full reload required: Egress file list is fetched once on page load and not auto-refreshed
       await this.page.reload();
@@ -311,6 +322,8 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
       rows = await egressTable.locator("tbody tr").all();
       if (rows.length >= expectedCount) return;
     }
-    throw new Error(`Timed out waiting for ${expectedCount} files (timeout: ${timeout}ms)`);
+    throw new Error(
+      `Timed out waiting for ${expectedCount} files (timeout: ${timeout}ms)`,
+    );
   }
 }

--- a/e2e/pw/pages/TransferMaterialsTab.ts
+++ b/e2e/pw/pages/TransferMaterialsTab.ts
@@ -56,16 +56,18 @@ export class TransferMaterialsTab
       .check();
   }
 
-  async selectAction(action: "Copy" | "Move") {
+  async selectAction(
+    action: "Copy" | "Move",
+    direction: "egressToNetApp" | "netAppToEgress" = "egressToNetApp",
+  ) {
+    // Old screen has a Copy/Move control in each panel's inset: the NetApp inset
+    // drives Egress → NetApp, the Egress inset drives NetApp → Egress.
+    const inset =
+      direction === "egressToNetApp"
+        ? "netapp-inset-text"
+        : "egress-inset-text";
     await this.page
-      .getByTestId("netapp-inset-text")
-      .getByRole("button", { name: action })
-      .click();
-  }
-
-  async selectReverseAction(action: "Copy" | "Move") {
-    await this.page
-      .getByTestId("egress-inset-text")
+      .getByTestId(inset)
       .getByRole("button", { name: action })
       .click();
   }

--- a/e2e/pw/pages/TransferMaterialsTab.ts
+++ b/e2e/pw/pages/TransferMaterialsTab.ts
@@ -1,12 +1,17 @@
-import { Page, expect } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { TransferMaterialsTabApi } from "./TransferMaterialsTabApi";
+import { BaseTransferMaterialsTab } from "./BaseTransferMaterialsTab";
 
-export class TransferMaterialsTab implements TransferMaterialsTabApi {
-  private readonly page: Page;
-
-  constructor(page: Page) {
-    this.page = page;
-  }
+/**
+ * Old-screen Transfer Materials page object. Egress-side and common helpers come
+ * from `BaseTransferMaterialsTab`; this class carries the old-screen selectors
+ * (two side-by-side panels, per-panel inset Copy/Move, confirm modal).
+ */
+export class TransferMaterialsTab
+  extends BaseTransferMaterialsTab
+  implements TransferMaterialsTabApi
+{
+  protected readonly netAppWrapperTestId = "netapp-table-wrapper";
 
   async waitForEgressFiles() {
     await this.page
@@ -26,13 +31,6 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
       .click();
   }
 
-  async selectAllEgressFiles() {
-    await this.page
-      .getByTestId("egress-table-wrapper")
-      .getByLabel("Select folders and files")
-      .check();
-  }
-
   async selectEgressFiles(indices: number[]) {
     const rows = this.page
       .getByTestId("egress-table-wrapper")
@@ -48,27 +46,6 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
       .locator("tbody tr");
     for (const index of indices) {
       await rows.nth(index).locator('input[type="checkbox"]').check();
-    }
-  }
-
-  /**
-   * Sort the NetApp panel by last-modified date descending (two header clicks).
-   * The NetApp panel's date sort doesn't reliably toggle to descending, so this
-   * mirrors the click-twice approach specs relied on inline.
-   */
-  async sortNetAppByDateDescending() {
-    const header = this.page
-      .getByTestId("netapp-table-wrapper")
-      .getByRole("button", { name: "Last modified date" });
-    try {
-      await header.click({ timeout: 20_000 });
-      await this.waitForNetAppFiles();
-      await header.click({ timeout: 20_000 });
-      await this.waitForNetAppFiles();
-    } catch {
-      console.log(
-        "  [sortNetAppByDateDescending] date sort skipped (best-effort)",
-      );
     }
   }
 
@@ -128,15 +105,6 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
     return await this.page.getByTestId("transfer-progress-metrics").innerText();
   }
 
-  async selectEgressFileByName(fileName: string) {
-    const row = this.page
-      .getByTestId("egress-table-wrapper")
-      .locator("tbody tr", { hasText: fileName });
-    const checkbox = row.locator('input[type="checkbox"]');
-    await checkbox.scrollIntoViewIfNeeded();
-    await checkbox.check();
-  }
-
   async selectNetAppFileByName(fileName: string) {
     const row = this.page
       .getByTestId("netapp-table-wrapper")
@@ -147,30 +115,17 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
   }
 
   /**
-   * Select a NetApp source row by exact filename. Throws with a clear
-   * fixture-missing message if the row isn't in the loaded listing.
-   *
-   * The NetApp panel's date sort doesn't reliably toggle to descending
-   * and pagination isn't triggered by Playwright scrolls, so locating a
-   * just-uploaded file is unreliable. The story's contract is therefore
-   * that the default-mode NetApp -> Egress spec works against a stable
-   * pre-seeded fixture file — see `helpers/constants.ts`
-   * (NETAPP_FIXTURE_FILENAME) and `tests/seed-netapp-fixture.setup.ts`.
-   * The fixture's name pattern keeps it outside the automated cleanup
-   * helpers' scope.
+   * Select a NetApp source row by exact filename; throws a clear fixture-missing
+   * message if absent. The panel's unreliable sort + pagination make locating a
+   * just-uploaded file flaky, so the default-mode spec runs against a stable
+   * pre-seeded fixture (see `tests/seed-netapp-fixture.setup.ts`).
    */
   async selectNetAppFileByExactName(fileName: string) {
     const row = this.page
       .getByTestId("netapp-table-wrapper")
       .locator("tbody tr", { hasText: fileName });
     if ((await row.count()) === 0) {
-      throw new Error(
-        `Required NetApp fixture '${fileName}' not found in the NetApp panel.\n` +
-          `  Seed it via:\n` +
-          `    bash:       RUN_SEED=1 npx playwright test --project=seed-netapp-fixture\n` +
-          `    powershell: $env:RUN_SEED=1; npx playwright test --project=seed-netapp-fixture\n` +
-          `  See README "Required NetApp fixture" for details.`,
-      );
+      throw this.fixtureMissingError(fileName, "NetApp panel");
     }
     const checkbox = row.locator('input[type="checkbox"]').first();
     await checkbox.scrollIntoViewIfNeeded();
@@ -178,11 +133,10 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
   }
 
   /**
-   * Scroll the NetApp panel until a row containing `fileName` appears in
-   * the DOM, then select its checkbox. Needed because the NetApp listing
-   * paginates via continuation tokens — a freshly-uploaded file with a
-   * recent date is at the bottom of the default ascending sort and won't
-   * be in the DOM until the panel scrolls and triggers more page loads.
+   * Scroll the NetApp panel until a row containing `fileName` appears, then
+   * select it. The listing paginates via continuation tokens, so a
+   * freshly-uploaded file at the bottom of the ascending sort isn't in the DOM
+   * until scrolling triggers more page loads.
    */
   async selectNetAppFileByNameWithScroll(
     fileName: string,
@@ -249,50 +203,6 @@ export class TransferMaterialsTab implements TransferMaterialsTabApi {
     const netappTable = this.page.getByTestId("netapp-table-wrapper");
     await expect(netappTable).toBeVisible({ timeout });
     await expect(netappTable).toContainText(fileName, { timeout });
-  }
-
-  async navigateToFolder(folderName: string) {
-    await this.page.getByRole("button", { name: folderName }).click();
-  }
-
-  /**
-   * Wait until a file with the given name appears in the Egress panel,
-   * reloading and re-navigating into the supplied folder path on each
-   * retry. Egress fetches the file list once on page load and does not
-   * auto-refresh, so a plain `waitFor` will spin against a stale DOM if
-   * the upload is still being indexed when navigation lands.
-   *
-   * `folderPath` is the sequence of folder names to click into after the
-   * page reload (e.g. ["4. Served Evidence", uploadSubfolder]).
-   */
-  async waitForEgressFileByName(
-    fileName: string,
-    folderPath: string[],
-    timeout: number = 300_000,
-  ) {
-    const egressTable = this.page.getByTestId("egress-table-wrapper");
-    const start = Date.now();
-
-    const fileVisible = async () =>
-      (await egressTable.locator("tbody tr", { hasText: fileName }).count()) >
-      0;
-
-    if (await fileVisible()) return;
-
-    while (Date.now() - start < timeout) {
-      console.log(`  Waiting for ${fileName} to be indexed; refreshing...`);
-      await this.page.waitForTimeout(5_000);
-      await this.page.reload();
-      await this.waitForEgressFiles();
-      for (const folder of folderPath) {
-        await this.navigateToFolder(folder);
-        await this.waitForEgressFiles();
-      }
-      if (await fileVisible()) return;
-    }
-    throw new Error(
-      `Timed out waiting for ${fileName} to appear in Egress panel (timeout: ${timeout}ms)`,
-    );
   }
 
   /** Wait until at least `expectedCount` file rows appear in the Egress panel folder, refreshing periodically. */

--- a/e2e/pw/pages/TransferMaterialsTabApi.ts
+++ b/e2e/pw/pages/TransferMaterialsTabApi.ts
@@ -14,8 +14,16 @@ export interface TransferMaterialsTabApi {
   /** Sort the shared-drive/NetApp panel by last-modified date descending. */
   sortNetAppByDateDescending(): Promise<void>;
   selectEgressFileByName(fileName: string): Promise<void>;
-  selectAction(action: "Copy" | "Move"): Promise<void>;
-  selectReverseAction(action: "Copy" | "Move"): Promise<void>;
+  /**
+   * Initiate a transfer in the given direction (default Egress → NetApp).
+   * `direction` only matters on the old screen, which has a Copy/Move control in
+   * each panel's inset; the new screen has a single shared control and ignores
+   * it (direction is implied by the current source).
+   */
+  selectAction(
+    action: "Copy" | "Move",
+    direction?: "egressToNetApp" | "netAppToEgress",
+  ): Promise<void>;
   /** Confirm the pending transfer. `action` must match the Copy/Move just
    * initiated — the new screen's confirm button reads "<action> to <folder>". */
   confirmTransfer(action: "Copy" | "Move"): Promise<void>;

--- a/e2e/pw/pages/TransferMaterialsTabApi.ts
+++ b/e2e/pw/pages/TransferMaterialsTabApi.ts
@@ -16,7 +16,9 @@ export interface TransferMaterialsTabApi {
   selectEgressFileByName(fileName: string): Promise<void>;
   selectAction(action: "Copy" | "Move"): Promise<void>;
   selectReverseAction(action: "Copy" | "Move"): Promise<void>;
-  confirmTransfer(): Promise<void>;
+  /** Confirm the pending transfer. `action` must match the Copy/Move just
+   * initiated — the new screen's confirm button reads "<action> to <folder>". */
+  confirmTransfer(action: "Copy" | "Move"): Promise<void>;
   waitForTransferComplete(timeout?: number): Promise<void>;
   /** Recover from a transfer error page back to case management so the tab can
    * be re-entered. No-op when not on an error page. */

--- a/e2e/pw/pages/TransferMaterialsTabApi.ts
+++ b/e2e/pw/pages/TransferMaterialsTabApi.ts
@@ -1,12 +1,8 @@
 /**
- * Screen-agnostic contract for the Transfer Materials tab, implemented by both
- * the old-screen page object (`TransferMaterialsTab`) and the new-screen one
- * (`TransferMaterialsTabV1`). Specs construct via `getTransferMaterialsTab`
- * and depend only on this surface, so a spec never references a
+ * Screen-agnostic Transfer Materials contract, implemented by both
+ * `TransferMaterialsTab` (old) and `TransferMaterialsTabV1` (new). Specs build
+ * via `getTransferMaterialsTab` and depend only on this surface, never a
  * screen-specific selector.
- *
- * The surface is exactly the set of methods the specs call today. New-screen
- * work fills in the v1 implementation behind these same signatures.
  */
 export interface TransferMaterialsTabApi {
   waitForEgressFiles(): Promise<void>;
@@ -22,18 +18,12 @@ export interface TransferMaterialsTabApi {
   selectReverseAction(action: "Copy" | "Move"): Promise<void>;
   confirmTransfer(): Promise<void>;
   waitForTransferComplete(timeout?: number): Promise<void>;
-  /**
-   * Recover from the new-screen transfer error page back to case
-   * management, so the Transfer Materials tab can be re-entered. No-op on
-   * the old screen (which keeps the transfer view mounted through errors).
-   */
+  /** Recover from a transfer error page back to case management so the tab can
+   * be re-entered. No-op when not on an error page. */
   dismissTransferErrorIfPresent(): Promise<void>;
-  /**
-   * Assert the named file is present in the NetApp / shared-drive panel.
-   * On the old screen both panels are visible so it checks the panel in
-   * place; on the new screen only the source panel renders, so it switches
-   * to the shared drive first. Throws if the file never appears.
-   */
+  /** Assert the named file is present in the NetApp / shared-drive panel
+   * (old screen checks in place; new screen switches to the shared drive
+   * first). Throws if it never appears. */
   verifyNetAppContainsFile(fileName: string, timeout?: number): Promise<void>;
   navigateToFolder(folderName: string): Promise<void>;
   waitForEgressFileByName(

--- a/e2e/pw/pages/TransferMaterialsTabApi.ts
+++ b/e2e/pw/pages/TransferMaterialsTabApi.ts
@@ -1,0 +1,44 @@
+/**
+ * Screen-agnostic contract for the Transfer Materials tab, implemented by both
+ * the old-screen page object (`TransferMaterialsTab`) and the new-screen one
+ * (`TransferMaterialsTabV1`). Specs construct via `getTransferMaterialsTab`
+ * and depend only on this surface, so a spec never references a
+ * screen-specific selector.
+ *
+ * The surface is exactly the set of methods the specs call today. New-screen
+ * work fills in the v1 implementation behind these same signatures.
+ */
+export interface TransferMaterialsTabApi {
+  waitForEgressFiles(): Promise<void>;
+  waitForNetAppFiles(): Promise<void>;
+  switchToNetAppSource(): Promise<void>;
+  selectAllEgressFiles(): Promise<void>;
+  selectNetAppFiles(indices: number[]): Promise<void>;
+  selectNetAppFileByExactName(fileName: string): Promise<void>;
+  /** Sort the shared-drive/NetApp panel by last-modified date descending. */
+  sortNetAppByDateDescending(): Promise<void>;
+  selectEgressFileByName(fileName: string): Promise<void>;
+  selectAction(action: "Copy" | "Move"): Promise<void>;
+  selectReverseAction(action: "Copy" | "Move"): Promise<void>;
+  confirmTransfer(): Promise<void>;
+  waitForTransferComplete(timeout?: number): Promise<void>;
+  /**
+   * Recover from the new-screen transfer error page back to case
+   * management, so the Transfer Materials tab can be re-entered. No-op on
+   * the old screen (which keeps the transfer view mounted through errors).
+   */
+  dismissTransferErrorIfPresent(): Promise<void>;
+  /**
+   * Assert the named file is present in the NetApp / shared-drive panel.
+   * On the old screen both panels are visible so it checks the panel in
+   * place; on the new screen only the source panel renders, so it switches
+   * to the shared drive first. Throws if the file never appears.
+   */
+  verifyNetAppContainsFile(fileName: string, timeout?: number): Promise<void>;
+  navigateToFolder(folderName: string): Promise<void>;
+  waitForEgressFileByName(
+    fileName: string,
+    folderPath: string[],
+    timeout?: number,
+  ): Promise<void>;
+}

--- a/e2e/pw/pages/TransferMaterialsTabV1.ts
+++ b/e2e/pw/pages/TransferMaterialsTabV1.ts
@@ -139,6 +139,18 @@ export class TransferMaterialsTabV1
     ]);
 
     if (TRANSFER_ERROR_ROUTE.test(this.page.url())) {
+      // waitForURL resolves on the URL change, before React renders the error
+      // page — so wait for its heading before reading <main>, or innerText()
+      // can return the stale transfer-materials <main> (every page wraps its
+      // content in <main id="main-content">). Best-effort: the rarer
+      // permissions / resolve-file-path routes use a different heading, so the
+      // wait lapses and we still surface whatever the page shows.
+      await this.page
+        .getByRole("heading", {
+          name: "There is a problem transferring files",
+        })
+        .waitFor({ state: "visible", timeout: 15_000 })
+        .catch(() => {});
       const detail = await this.page
         .locator("main")
         .innerText()

--- a/e2e/pw/pages/TransferMaterialsTabV1.ts
+++ b/e2e/pw/pages/TransferMaterialsTabV1.ts
@@ -114,11 +114,12 @@ export class TransferMaterialsTabV1
     await checkbox.check({ force: true });
   }
 
-  async selectAction(action: "Copy" | "Move"): Promise<void> {
-    await this.clickTransferControl(action);
-  }
-
-  async selectReverseAction(action: "Copy" | "Move"): Promise<void> {
+  async selectAction(
+    action: "Copy" | "Move",
+    _direction?: "egressToNetApp" | "netAppToEgress",
+  ): Promise<void> {
+    // New screen: one shared control for both directions (Move renders only when
+    // the source is Egress), so the direction is implied by the current source.
     await this.clickTransferControl(action);
   }
 

--- a/e2e/pw/pages/TransferMaterialsTabV1.ts
+++ b/e2e/pw/pages/TransferMaterialsTabV1.ts
@@ -22,9 +22,6 @@ export class TransferMaterialsTabV1
   implements TransferMaterialsTabApi
 {
   protected readonly netAppWrapperTestId = "shared drive-table-wrapper";
-  // Remembered so confirmTransfer knows whether the destination-page button
-  // reads "Copy to …" or "Move to …".
-  private lastAction: "Copy" | "Move" = "Copy";
 
   /** Row checkbox for a shared-drive file, by its exact aria-label. */
   private fileCheckbox(fileName: string): Locator {
@@ -36,7 +33,6 @@ export class TransferMaterialsTabV1
   /** Click the shared Copy/Move control. Renders in a top and bottom bar (target
    * the first); Move only appears when the source is Egress. */
   private async clickTransferControl(action: "Copy" | "Move"): Promise<void> {
-    this.lastAction = action;
     await this.page
       .getByRole("button", { name: `${action} selected` })
       .first()
@@ -129,13 +125,14 @@ export class TransferMaterialsTabV1
   /**
    * Confirm the transfer. No modal on the new screen: Copy/Move already
    * navigated to the destination tree — pick the first selectable folder (the
-   * connected root) and click the `<Copy|Move> to <folder>` button.
+   * connected root) and click the `<action> to <folder>` button. `action` must
+   * match the Copy/Move just initiated (the button label depends on it).
    */
-  async confirmTransfer(): Promise<void> {
+  async confirmTransfer(action: "Copy" | "Move"): Promise<void> {
     const destination = new TransferDestinationPage(this.page);
     await destination.waitForLoaded();
     await destination.selectFirstSelectableFolder();
-    await destination.confirm(this.lastAction);
+    await destination.confirm(action);
   }
 
   /**

--- a/e2e/pw/pages/TransferMaterialsTabV1.ts
+++ b/e2e/pw/pages/TransferMaterialsTabV1.ts
@@ -1,0 +1,295 @@
+import { Page, expect } from "@playwright/test";
+import { TransferMaterialsTabApi } from "./TransferMaterialsTabApi";
+import { TransferDestinationPage } from "./TransferDestinationPage";
+
+/**
+ * New-screen (redesigned / v1) Transfer Materials page object.
+ *
+ * Selected by `getTransferMaterialsTab` when `TRANSFER_MATERIALS_V1` is on.
+ * The old-screen page object (`TransferMaterialsTab`) is unchanged; this class
+ * carries the new-screen selectors and flow:
+ *   - the NetApp table is now named "shared drive" (wrapper id
+ *     `shared drive-table-wrapper`, loader `shared drive-folder-table-loader`);
+ *   - Copy/Move are `Copy selected` / `Move selected` buttons in
+ *     TransferControls, not per-panel inset text;
+ *   - the direction toggle is a `View Shared Drive` / `View Egress` link button;
+ *   - there is no confirm modal — `Copy selected` / `Move selected` navigate to
+ *     a destination-tree page where you pick a folder and confirm with
+ *     `<Copy|Move> to <folder>` (driven via `TransferDestinationPage`);
+ *   - success/error use the unchanged success banner + the new error routes
+ *     (`transfer-errors` / `transfer-permissions-error` / `transfer-resolve-file-path`).
+ * The Egress table keeps its name, per-row checkboxes and select-all label.
+ */
+export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
+  private readonly page: Page;
+  // Remembered from selectAction/selectReverseAction so confirmTransfer knows
+  // whether the destination-page confirm button reads "Copy to …" or "Move to …".
+  private lastAction: "Copy" | "Move" = "Copy";
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  /** Click the shared Copy/Move control in TransferControls. On the new screen
+   * both transfer directions use the same `Copy selected` / `Move selected`
+   * buttons (Move only renders when the source is Egress). The controls render
+   * in both a top and bottom bar, so target the first. */
+  private async clickTransferControl(action: "Copy" | "Move"): Promise<void> {
+    this.lastAction = action;
+    await this.page
+      .getByRole("button", { name: `${action} selected` })
+      .first()
+      .click();
+  }
+
+  /**
+   * Wait until a source panel's folder listing has finished loading. The loader
+   * spinner mounts a tick *after* navigation kicks off the fetch, so a bare
+   * wait-for-hidden races: Playwright treats the not-yet-mounted spinner as
+   * "hidden" and returns instantly, before the list has actually loaded — and a
+   * subsequent instantaneous `.count()` check then sees an empty table. Wait for
+   * the spinner to appear first, then disappear; tolerate a rare instant load
+   * where it never shows.
+   */
+  private async waitForFolderSettled(tableName: string): Promise<void> {
+    const loader = this.page.getByTestId(`${tableName}-folder-table-loader`);
+    await loader.waitFor({ state: "visible", timeout: 10_000 }).catch(() => {});
+    await loader.waitFor({ state: "hidden", timeout: 120_000 });
+  }
+
+  async waitForEgressFiles(): Promise<void> {
+    await this.waitForFolderSettled("egress");
+  }
+
+  async waitForNetAppFiles(): Promise<void> {
+    await this.waitForFolderSettled("shared drive");
+  }
+
+  async switchToNetAppSource(): Promise<void> {
+    // The toggle renders in both a top and bottom control bar; target the first.
+    await this.page
+      .getByRole("button", { name: "View Shared Drive" })
+      .first()
+      .click();
+  }
+
+  async selectAllEgressFiles(): Promise<void> {
+    await this.page
+      .getByTestId("egress-table-wrapper")
+      .getByLabel("Select folders and files")
+      .check();
+  }
+
+  async selectNetAppFiles(indices: number[]): Promise<void> {
+    // Target the per-row checkboxes by their aria-label ("select file …" /
+    // "select folder …", set by the Checkbox component), page-scoped. On the
+    // new screen only the shared-drive panel is shown while it's the source, so
+    // these are its rows. This avoids a `tbody tr` chain that doesn't interact
+    // reliably against the real shared-drive table.
+    const checkboxes = this.page.locator(
+      'input[type="checkbox"][aria-label^="select file"], input[type="checkbox"][aria-label^="select folder"]',
+    );
+    for (const index of indices) {
+      const checkbox = checkboxes.nth(index);
+      await checkbox.scrollIntoViewIfNeeded().catch(() => {});
+      await checkbox.check({ force: true });
+    }
+  }
+
+  /**
+   * Sort the shared-drive panel by last-modified date descending (two header
+   * clicks). Best-effort: the panel's date sort is unreliable and source
+   * identity doesn't matter for the transfer, so a flaky/slow header (e.g. a
+   * folder churning through many subfolders) is tolerated — proceed unsorted.
+   */
+  async sortNetAppByDateDescending(): Promise<void> {
+    const header = this.page
+      .getByTestId("shared drive-table-wrapper")
+      .getByRole("button", { name: "Last modified date" });
+    try {
+      await header.click({ timeout: 20_000 });
+      await this.waitForNetAppFiles();
+      await header.click({ timeout: 20_000 });
+      await this.waitForNetAppFiles();
+    } catch {
+      console.log("  [sortNetAppByDateDescending] date sort skipped (best-effort)");
+    }
+  }
+
+  /**
+   * Select a shared-drive (NetApp) source row by exact filename. Throws with a
+   * clear fixture-missing message if the row isn't in the loaded listing — the
+   * default-mode NetApp -> Egress spec runs against a stable pre-seeded fixture
+   * (see `helpers/constants.ts` NETAPP_FIXTURE_FILENAME and
+   * `tests/seed-netapp-fixture.setup.ts`).
+   */
+  async selectNetAppFileByExactName(fileName: string): Promise<void> {
+    // Gate on the target row's checkbox by its exact aria-label
+    // ("select file <name>"), page-scoped — this is the same element the
+    // selection uses, so if it attaches we can select it. We deliberately
+    // wait for `attached` rather than a `visible` `tbody tr`: on the real
+    // shared-drive table rows can be present in the DOM yet not "visible"
+    // to Playwright, and switching source doesn't reliably re-trigger the
+    // loader spinner, so a wrapper/`tbody tr` visibility gate spuriously
+    // reports a present fixture as missing. The busy environment's listing
+    // can also take well over 30s to populate, hence the generous timeout.
+    const checkbox = this.page
+      .locator(`input[type="checkbox"][aria-label="select file ${fileName}"]`)
+      .first();
+    try {
+      await checkbox.waitFor({ state: "attached", timeout: 120_000 });
+    } catch {
+      throw new Error(
+        `Required NetApp fixture '${fileName}' not found in the shared drive panel.\n` +
+          `  Seed it via:\n` +
+          `    bash:       RUN_SEED=1 npx playwright test --project=seed-netapp-fixture\n` +
+          `    powershell: $env:RUN_SEED=1; npx playwright test --project=seed-netapp-fixture\n` +
+          `  See README "Required NetApp fixture" for details.`,
+      );
+    }
+    await checkbox.scrollIntoViewIfNeeded().catch(() => {});
+    await checkbox.check({ force: true });
+  }
+
+  async selectEgressFileByName(fileName: string): Promise<void> {
+    const row = this.page
+      .getByTestId("egress-table-wrapper")
+      .locator("tbody tr", { hasText: fileName });
+    const checkbox = row.locator('input[type="checkbox"]');
+    await checkbox.scrollIntoViewIfNeeded();
+    await checkbox.check();
+  }
+
+  async selectAction(action: "Copy" | "Move"): Promise<void> {
+    await this.clickTransferControl(action);
+  }
+
+  async selectReverseAction(action: "Copy" | "Move"): Promise<void> {
+    await this.clickTransferControl(action);
+  }
+
+  /**
+   * Confirm the transfer. On the new screen there is no modal: `Copy selected` /
+   * `Move selected` (via selectAction/selectReverseAction) navigated to the
+   * destination page. Pick the target folder in the tree — the connected root
+   * folder for Egress→NetApp, or the first Egress subfolder for NetApp→Egress —
+   * then click the `<Copy|Move> to <folder>` confirm button.
+   */
+  async confirmTransfer(): Promise<void> {
+    const destination = new TransferDestinationPage(this.page);
+    await destination.waitForLoaded();
+    await destination.selectFirstSelectableFolder();
+    await destination.confirm(this.lastAction);
+  }
+
+  /**
+   * Wait for the transfer to finish. After confirming, the screen shows the
+   * validating/indexing spinner, then returns to case management and shows the
+   * success banner (`transfer-success-notification-banner`, unchanged). A failed
+   * transfer instead navigates to one of the new error routes.
+   */
+  async waitForTransferComplete(timeout: number = 300_000): Promise<void> {
+    const successBanner = this.page.getByTestId(
+      "transfer-success-notification-banner",
+    );
+    const errorRoute =
+      /\/case\/\d+\/case-management\/(transfer-errors|transfer-permissions-error|transfer-resolve-file-path)/;
+
+    await Promise.race([
+      successBanner.waitFor({ state: "visible", timeout }),
+      this.page.waitForURL(errorRoute, { timeout }),
+    ]);
+
+    if (errorRoute.test(this.page.url())) {
+      const detail = await this.page
+        .locator("main")
+        .innerText()
+        .catch(() => "");
+      throw new Error(
+        `Transfer failed — navigated to ${this.page.url()}\n${detail}`,
+      );
+    }
+
+    await expect(successBanner).toBeVisible();
+  }
+
+  /**
+   * If the new screen is parked on a transfer error route (reached after a
+   * failed or duplicate-file-rejected transfer), follow the page's "Back"
+   * link to return to case management, where the tablist is available again
+   * for re-entering the Transfer Materials tab. No-op when not on an error
+   * route (e.g. after a successful transfer, which lands on case management
+   * with the success banner already).
+   */
+  async dismissTransferErrorIfPresent(): Promise<void> {
+    const errorRoute =
+      /\/case\/\d+\/case-management\/(transfer-errors|transfer-permissions-error|transfer-resolve-file-path)/;
+    if (!errorRoute.test(this.page.url())) return;
+    await this.page.getByRole("link", { name: "Back", exact: true }).click();
+  }
+
+  /**
+   * Verify a file landed in the shared-drive panel. The new screen shows
+   * only the source panel, so switch to the shared drive to view what
+   * landed there, then wait for the file's row checkbox (by exact
+   * aria-label) to attach — the same attached-not-visible gate
+   * `selectNetAppFileByExactName` uses, since shared-drive rows can be in
+   * the DOM without being "visible" to Playwright. The generous timeout
+   * absorbs both the slow listing load and any post-copy indexing lag.
+   */
+  async verifyNetAppContainsFile(
+    fileName: string,
+    timeout: number = 60_000,
+  ): Promise<void> {
+    await this.switchToNetAppSource();
+    await this.waitForNetAppFiles();
+    const checkbox = this.page
+      .locator(`input[type="checkbox"][aria-label="select file ${fileName}"]`)
+      .first();
+    await checkbox.waitFor({ state: "attached", timeout });
+  }
+
+  async navigateToFolder(folderName: string): Promise<void> {
+    await this.page.getByRole("button", { name: folderName }).click();
+  }
+
+  /**
+   * Wait until a file with the given name appears in the Egress panel. Egress
+   * fetches a folder's list when you navigate into it and doesn't auto-refresh,
+   * so each retry does a full `page.reload()` (which busts the React Query cache
+   * so the freshly-indexed file is actually re-fetched — an in-app re-navigation
+   * serves the stale cached listing) and re-navigates the folder path from the
+   * top. On the new screen the transfer-materials route + Egress-as-source
+   * survive the reload, so the panel comes back and shows the updated listing.
+   */
+  async waitForEgressFileByName(
+    fileName: string,
+    folderPath: string[],
+    timeout: number = 300_000,
+  ): Promise<void> {
+    const egressTable = this.page.getByTestId("egress-table-wrapper");
+    const start = Date.now();
+
+    const fileVisible = async () =>
+      (await egressTable
+        .locator("tbody tr", { hasText: fileName })
+        .count()) > 0;
+
+    if (await fileVisible()) return;
+
+    while (Date.now() - start < timeout) {
+      console.log(`  Waiting for ${fileName} to be indexed; refreshing...`);
+      await this.page.waitForTimeout(5_000);
+      await this.page.reload();
+      await this.waitForEgressFiles();
+      for (const folder of folderPath) {
+        await this.navigateToFolder(folder);
+        await this.waitForEgressFiles();
+      }
+      if (await fileVisible()) return;
+    }
+    throw new Error(
+      `Timed out waiting for ${fileName} to appear in Egress panel (timeout: ${timeout}ms)`,
+    );
+  }
+}

--- a/e2e/pw/pages/TransferMaterialsTabV1.ts
+++ b/e2e/pw/pages/TransferMaterialsTabV1.ts
@@ -3,37 +3,27 @@ import { TransferMaterialsTabApi } from "./TransferMaterialsTabApi";
 import { TransferDestinationPage } from "./TransferDestinationPage";
 
 /**
- * New-screen (redesigned / v1) Transfer Materials page object.
- *
- * Selected by `getTransferMaterialsTab` when `TRANSFER_MATERIALS_V1` is on.
- * The old-screen page object (`TransferMaterialsTab`) is unchanged; this class
- * carries the new-screen selectors and flow:
- *   - the NetApp table is now named "shared drive" (wrapper id
- *     `shared drive-table-wrapper`, loader `shared drive-folder-table-loader`);
- *   - Copy/Move are `Copy selected` / `Move selected` buttons in
- *     TransferControls, not per-panel inset text;
- *   - the direction toggle is a `View Shared Drive` / `View Egress` link button;
- *   - there is no confirm modal — `Copy selected` / `Move selected` navigate to
- *     a destination-tree page where you pick a folder and confirm with
- *     `<Copy|Move> to <folder>` (driven via `TransferDestinationPage`);
- *   - success/error use the unchanged success banner + the new error routes
- *     (`transfer-errors` / `transfer-permissions-error` / `transfer-resolve-file-path`).
- * The Egress table keeps its name, per-row checkboxes and select-all label.
+ * New-screen (v1) Transfer Materials page object, selected by
+ * `getTransferMaterialsTab` when `TRANSFER_MATERIALS_V1` is on. Differs from the
+ * old screen: NetApp table renamed "shared drive"; Copy/Move are
+ * `Copy selected` / `Move selected` buttons; direction toggles via a
+ * `View Shared Drive` / `View Egress` link; no confirm modal (Copy/Move navigate
+ * to a destination-tree page, driven by `TransferDestinationPage`); errors use
+ * the new `transfer-errors` / `transfer-permissions-error` /
+ * `transfer-resolve-file-path` routes. The Egress table is unchanged.
  */
 export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
   private readonly page: Page;
-  // Remembered from selectAction/selectReverseAction so confirmTransfer knows
-  // whether the destination-page confirm button reads "Copy to …" or "Move to …".
+  // Remembered so confirmTransfer knows whether the destination-page button
+  // reads "Copy to …" or "Move to …".
   private lastAction: "Copy" | "Move" = "Copy";
 
   constructor(page: Page) {
     this.page = page;
   }
 
-  /** Click the shared Copy/Move control in TransferControls. On the new screen
-   * both transfer directions use the same `Copy selected` / `Move selected`
-   * buttons (Move only renders when the source is Egress). The controls render
-   * in both a top and bottom bar, so target the first. */
+  /** Click the shared Copy/Move control. Renders in a top and bottom bar (target
+   * the first); Move only appears when the source is Egress. */
   private async clickTransferControl(action: "Copy" | "Move"): Promise<void> {
     this.lastAction = action;
     await this.page
@@ -43,13 +33,10 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
   }
 
   /**
-   * Wait until a source panel's folder listing has finished loading. The loader
-   * spinner mounts a tick *after* navigation kicks off the fetch, so a bare
-   * wait-for-hidden races: Playwright treats the not-yet-mounted spinner as
-   * "hidden" and returns instantly, before the list has actually loaded — and a
-   * subsequent instantaneous `.count()` check then sees an empty table. Wait for
-   * the spinner to appear first, then disappear; tolerate a rare instant load
-   * where it never shows.
+   * Wait for a source panel's listing to load. The loader mounts a tick after
+   * the fetch starts, so wait for it to appear then disappear; a bare
+   * wait-for-hidden races and returns against an empty table. Tolerate a rare
+   * instant load where the spinner never shows.
    */
   private async waitForFolderSettled(tableName: string): Promise<void> {
     const loader = this.page.getByTestId(`${tableName}-folder-table-loader`);
@@ -66,7 +53,7 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
   }
 
   async switchToNetAppSource(): Promise<void> {
-    // The toggle renders in both a top and bottom control bar; target the first.
+    // Toggle renders in a top and bottom bar; target the first.
     await this.page
       .getByRole("button", { name: "View Shared Drive" })
       .first()
@@ -81,11 +68,9 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
   }
 
   async selectNetAppFiles(indices: number[]): Promise<void> {
-    // Target the per-row checkboxes by their aria-label ("select file …" /
-    // "select folder …", set by the Checkbox component), page-scoped. On the
-    // new screen only the shared-drive panel is shown while it's the source, so
-    // these are its rows. This avoids a `tbody tr` chain that doesn't interact
-    // reliably against the real shared-drive table.
+    // Select per-row checkboxes by aria-label (page-scoped, forced). Only the
+    // shared-drive panel shows while it's the source, so these are its rows;
+    // a `tbody tr` chain doesn't interact reliably against the real table.
     const checkboxes = this.page.locator(
       'input[type="checkbox"][aria-label^="select file"], input[type="checkbox"][aria-label^="select folder"]',
     );
@@ -98,9 +83,8 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
 
   /**
    * Sort the shared-drive panel by last-modified date descending (two header
-   * clicks). Best-effort: the panel's date sort is unreliable and source
-   * identity doesn't matter for the transfer, so a flaky/slow header (e.g. a
-   * folder churning through many subfolders) is tolerated — proceed unsorted.
+   * clicks). Best-effort: the date sort is unreliable and source identity
+   * doesn't matter, so a flaky/slow header is tolerated — proceed unsorted.
    */
   async sortNetAppByDateDescending(): Promise<void> {
     const header = this.page
@@ -117,22 +101,14 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
   }
 
   /**
-   * Select a shared-drive (NetApp) source row by exact filename. Throws with a
-   * clear fixture-missing message if the row isn't in the loaded listing — the
-   * default-mode NetApp -> Egress spec runs against a stable pre-seeded fixture
-   * (see `helpers/constants.ts` NETAPP_FIXTURE_FILENAME and
-   * `tests/seed-netapp-fixture.setup.ts`).
+   * Select a shared-drive source row by exact filename; throws a clear
+   * fixture-missing message if absent (see `tests/seed-netapp-fixture.setup.ts`).
    */
   async selectNetAppFileByExactName(fileName: string): Promise<void> {
-    // Gate on the target row's checkbox by its exact aria-label
-    // ("select file <name>"), page-scoped — this is the same element the
-    // selection uses, so if it attaches we can select it. We deliberately
-    // wait for `attached` rather than a `visible` `tbody tr`: on the real
-    // shared-drive table rows can be present in the DOM yet not "visible"
-    // to Playwright, and switching source doesn't reliably re-trigger the
-    // loader spinner, so a wrapper/`tbody tr` visibility gate spuriously
-    // reports a present fixture as missing. The busy environment's listing
-    // can also take well over 30s to populate, hence the generous timeout.
+    // Gate on the row checkbox being `attached`, not a `visible` `tbody tr`:
+    // shared-drive rows can be in the DOM but not "visible" to Playwright,
+    // source switches don't reliably re-trigger the loader, and the listing
+    // can take well over 30s — so a visibility gate false-negatives.
     const checkbox = this.page
       .locator(`input[type="checkbox"][aria-label="select file ${fileName}"]`)
       .first();
@@ -169,11 +145,9 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
   }
 
   /**
-   * Confirm the transfer. On the new screen there is no modal: `Copy selected` /
-   * `Move selected` (via selectAction/selectReverseAction) navigated to the
-   * destination page. Pick the target folder in the tree — the connected root
-   * folder for Egress→NetApp, or the first Egress subfolder for NetApp→Egress —
-   * then click the `<Copy|Move> to <folder>` confirm button.
+   * Confirm the transfer. No modal on the new screen: Copy/Move already
+   * navigated to the destination tree — pick the first selectable folder (the
+   * connected root) and click the `<Copy|Move> to <folder>` button.
    */
   async confirmTransfer(): Promise<void> {
     const destination = new TransferDestinationPage(this.page);
@@ -183,10 +157,8 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
   }
 
   /**
-   * Wait for the transfer to finish. After confirming, the screen shows the
-   * validating/indexing spinner, then returns to case management and shows the
-   * success banner (`transfer-success-notification-banner`, unchanged). A failed
-   * transfer instead navigates to one of the new error routes.
+   * Wait for completion: race the (unchanged) success banner against the new
+   * error routes, throwing with the page's error text if a transfer fails.
    */
   async waitForTransferComplete(timeout: number = 300_000): Promise<void> {
     const successBanner = this.page.getByTestId(
@@ -214,12 +186,9 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
   }
 
   /**
-   * If the new screen is parked on a transfer error route (reached after a
-   * failed or duplicate-file-rejected transfer), follow the page's "Back"
-   * link to return to case management, where the tablist is available again
-   * for re-entering the Transfer Materials tab. No-op when not on an error
-   * route (e.g. after a successful transfer, which lands on case management
-   * with the success banner already).
+   * If parked on a transfer error route (after a failed or duplicate-rejected
+   * transfer), follow the page's "Back" link to case management so the tab can
+   * be re-entered. No-op otherwise.
    */
   async dismissTransferErrorIfPresent(): Promise<void> {
     const errorRoute =
@@ -229,13 +198,9 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
   }
 
   /**
-   * Verify a file landed in the shared-drive panel. The new screen shows
-   * only the source panel, so switch to the shared drive to view what
-   * landed there, then wait for the file's row checkbox (by exact
-   * aria-label) to attach — the same attached-not-visible gate
-   * `selectNetAppFileByExactName` uses, since shared-drive rows can be in
-   * the DOM without being "visible" to Playwright. The generous timeout
-   * absorbs both the slow listing load and any post-copy indexing lag.
+   * Verify a file landed in the shared drive: switch to it as source and wait
+   * for the file's row checkbox to attach (attached-not-visible, as in
+   * selectNetAppFileByExactName). Timeout covers slow load + indexing lag.
    */
   async verifyNetAppContainsFile(
     fileName: string,
@@ -254,13 +219,10 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
   }
 
   /**
-   * Wait until a file with the given name appears in the Egress panel. Egress
-   * fetches a folder's list when you navigate into it and doesn't auto-refresh,
-   * so each retry does a full `page.reload()` (which busts the React Query cache
-   * so the freshly-indexed file is actually re-fetched — an in-app re-navigation
-   * serves the stale cached listing) and re-navigates the folder path from the
-   * top. On the new screen the transfer-materials route + Egress-as-source
-   * survive the reload, so the panel comes back and shows the updated listing.
+   * Wait for a file to appear in the Egress panel. Egress doesn't auto-refresh,
+   * so each retry does a full `page.reload()` (busts the React Query cache;
+   * in-app re-navigation serves the stale listing) and re-navigates the folder
+   * path. The transfer route + Egress-as-source survive the reload.
    */
   async waitForEgressFileByName(
     fileName: string,

--- a/e2e/pw/pages/TransferMaterialsTabV1.ts
+++ b/e2e/pw/pages/TransferMaterialsTabV1.ts
@@ -96,7 +96,9 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
       await header.click({ timeout: 20_000 });
       await this.waitForNetAppFiles();
     } catch {
-      console.log("  [sortNetAppByDateDescending] date sort skipped (best-effort)");
+      console.log(
+        "  [sortNetAppByDateDescending] date sort skipped (best-effort)",
+      );
     }
   }
 
@@ -233,9 +235,8 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
     const start = Date.now();
 
     const fileVisible = async () =>
-      (await egressTable
-        .locator("tbody tr", { hasText: fileName })
-        .count()) > 0;
+      (await egressTable.locator("tbody tr", { hasText: fileName }).count()) >
+      0;
 
     if (await fileVisible()) return;
 

--- a/e2e/pw/pages/TransferMaterialsTabV1.ts
+++ b/e2e/pw/pages/TransferMaterialsTabV1.ts
@@ -1,6 +1,12 @@
-import { Page, expect } from "@playwright/test";
+import { expect, Locator } from "@playwright/test";
 import { TransferMaterialsTabApi } from "./TransferMaterialsTabApi";
 import { TransferDestinationPage } from "./TransferDestinationPage";
+import { BaseTransferMaterialsTab } from "./BaseTransferMaterialsTab";
+
+// The new screen navigates to one of these routes on a failed or
+// duplicate-rejected transfer (used to detect + recover from the error page).
+const TRANSFER_ERROR_ROUTE =
+  /\/case\/\d+\/case-management\/(transfer-errors|transfer-permissions-error|transfer-resolve-file-path)/;
 
 /**
  * New-screen (v1) Transfer Materials page object, selected by
@@ -9,17 +15,22 @@ import { TransferDestinationPage } from "./TransferDestinationPage";
  * `Copy selected` / `Move selected` buttons; direction toggles via a
  * `View Shared Drive` / `View Egress` link; no confirm modal (Copy/Move navigate
  * to a destination-tree page, driven by `TransferDestinationPage`); errors use
- * the new `transfer-errors` / `transfer-permissions-error` /
- * `transfer-resolve-file-path` routes. The Egress table is unchanged.
+ * the routes above. Egress-side helpers come from `BaseTransferMaterialsTab`.
  */
-export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
-  private readonly page: Page;
+export class TransferMaterialsTabV1
+  extends BaseTransferMaterialsTab
+  implements TransferMaterialsTabApi
+{
+  protected readonly netAppWrapperTestId = "shared drive-table-wrapper";
   // Remembered so confirmTransfer knows whether the destination-page button
   // reads "Copy to …" or "Move to …".
   private lastAction: "Copy" | "Move" = "Copy";
 
-  constructor(page: Page) {
-    this.page = page;
+  /** Row checkbox for a shared-drive file, by its exact aria-label. */
+  private fileCheckbox(fileName: string): Locator {
+    return this.page
+      .locator(`input[type="checkbox"][aria-label="select file ${fileName}"]`)
+      .first();
   }
 
   /** Click the shared Copy/Move control. Renders in a top and bottom bar (target
@@ -60,13 +71,6 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
       .click();
   }
 
-  async selectAllEgressFiles(): Promise<void> {
-    await this.page
-      .getByTestId("egress-table-wrapper")
-      .getByLabel("Select folders and files")
-      .check();
-  }
-
   async selectNetAppFiles(indices: number[]): Promise<void> {
     // Select per-row checkboxes by aria-label (page-scoped, forced). Only the
     // shared-drive panel shows while it's the source, so these are its rows;
@@ -82,27 +86,6 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
   }
 
   /**
-   * Sort the shared-drive panel by last-modified date descending (two header
-   * clicks). Best-effort: the date sort is unreliable and source identity
-   * doesn't matter, so a flaky/slow header is tolerated — proceed unsorted.
-   */
-  async sortNetAppByDateDescending(): Promise<void> {
-    const header = this.page
-      .getByTestId("shared drive-table-wrapper")
-      .getByRole("button", { name: "Last modified date" });
-    try {
-      await header.click({ timeout: 20_000 });
-      await this.waitForNetAppFiles();
-      await header.click({ timeout: 20_000 });
-      await this.waitForNetAppFiles();
-    } catch {
-      console.log(
-        "  [sortNetAppByDateDescending] date sort skipped (best-effort)",
-      );
-    }
-  }
-
-  /**
    * Select a shared-drive source row by exact filename; throws a clear
    * fixture-missing message if absent (see `tests/seed-netapp-fixture.setup.ts`).
    */
@@ -111,31 +94,14 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
     // shared-drive rows can be in the DOM but not "visible" to Playwright,
     // source switches don't reliably re-trigger the loader, and the listing
     // can take well over 30s — so a visibility gate false-negatives.
-    const checkbox = this.page
-      .locator(`input[type="checkbox"][aria-label="select file ${fileName}"]`)
-      .first();
+    const checkbox = this.fileCheckbox(fileName);
     try {
       await checkbox.waitFor({ state: "attached", timeout: 120_000 });
     } catch {
-      throw new Error(
-        `Required NetApp fixture '${fileName}' not found in the shared drive panel.\n` +
-          `  Seed it via:\n` +
-          `    bash:       RUN_SEED=1 npx playwright test --project=seed-netapp-fixture\n` +
-          `    powershell: $env:RUN_SEED=1; npx playwright test --project=seed-netapp-fixture\n` +
-          `  See README "Required NetApp fixture" for details.`,
-      );
+      throw this.fixtureMissingError(fileName, "shared drive panel");
     }
     await checkbox.scrollIntoViewIfNeeded().catch(() => {});
     await checkbox.check({ force: true });
-  }
-
-  async selectEgressFileByName(fileName: string): Promise<void> {
-    const row = this.page
-      .getByTestId("egress-table-wrapper")
-      .locator("tbody tr", { hasText: fileName });
-    const checkbox = row.locator('input[type="checkbox"]');
-    await checkbox.scrollIntoViewIfNeeded();
-    await checkbox.check();
   }
 
   async selectAction(action: "Copy" | "Move"): Promise<void> {
@@ -166,15 +132,13 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
     const successBanner = this.page.getByTestId(
       "transfer-success-notification-banner",
     );
-    const errorRoute =
-      /\/case\/\d+\/case-management\/(transfer-errors|transfer-permissions-error|transfer-resolve-file-path)/;
 
     await Promise.race([
       successBanner.waitFor({ state: "visible", timeout }),
-      this.page.waitForURL(errorRoute, { timeout }),
+      this.page.waitForURL(TRANSFER_ERROR_ROUTE, { timeout }),
     ]);
 
-    if (errorRoute.test(this.page.url())) {
+    if (TRANSFER_ERROR_ROUTE.test(this.page.url())) {
       const detail = await this.page
         .locator("main")
         .innerText()
@@ -193,9 +157,7 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
    * be re-entered. No-op otherwise.
    */
   async dismissTransferErrorIfPresent(): Promise<void> {
-    const errorRoute =
-      /\/case\/\d+\/case-management\/(transfer-errors|transfer-permissions-error|transfer-resolve-file-path)/;
-    if (!errorRoute.test(this.page.url())) return;
+    if (!TRANSFER_ERROR_ROUTE.test(this.page.url())) return;
     await this.page.getByRole("link", { name: "Back", exact: true }).click();
   }
 
@@ -210,49 +172,6 @@ export class TransferMaterialsTabV1 implements TransferMaterialsTabApi {
   ): Promise<void> {
     await this.switchToNetAppSource();
     await this.waitForNetAppFiles();
-    const checkbox = this.page
-      .locator(`input[type="checkbox"][aria-label="select file ${fileName}"]`)
-      .first();
-    await checkbox.waitFor({ state: "attached", timeout });
-  }
-
-  async navigateToFolder(folderName: string): Promise<void> {
-    await this.page.getByRole("button", { name: folderName }).click();
-  }
-
-  /**
-   * Wait for a file to appear in the Egress panel. Egress doesn't auto-refresh,
-   * so each retry does a full `page.reload()` (busts the React Query cache;
-   * in-app re-navigation serves the stale listing) and re-navigates the folder
-   * path. The transfer route + Egress-as-source survive the reload.
-   */
-  async waitForEgressFileByName(
-    fileName: string,
-    folderPath: string[],
-    timeout: number = 300_000,
-  ): Promise<void> {
-    const egressTable = this.page.getByTestId("egress-table-wrapper");
-    const start = Date.now();
-
-    const fileVisible = async () =>
-      (await egressTable.locator("tbody tr", { hasText: fileName }).count()) >
-      0;
-
-    if (await fileVisible()) return;
-
-    while (Date.now() - start < timeout) {
-      console.log(`  Waiting for ${fileName} to be indexed; refreshing...`);
-      await this.page.waitForTimeout(5_000);
-      await this.page.reload();
-      await this.waitForEgressFiles();
-      for (const folder of folderPath) {
-        await this.navigateToFolder(folder);
-        await this.waitForEgressFiles();
-      }
-      if (await fileVisible()) return;
-    }
-    throw new Error(
-      `Timed out waiting for ${fileName} to appear in Egress panel (timeout: ${timeout}ms)`,
-    );
+    await this.fileCheckbox(fileName).waitFor({ state: "attached", timeout });
   }
 }

--- a/e2e/pw/pages/TransferMaterialsTabV1.ts
+++ b/e2e/pw/pages/TransferMaterialsTabV1.ts
@@ -64,11 +64,25 @@ export class TransferMaterialsTabV1
   }
 
   async switchToNetAppSource(): Promise<void> {
-    // Toggle renders in a top and bottom bar; target the first.
-    await this.page
+    // The direction toggle is a single button whose label flips: "View Shared
+    // Drive" while Egress is the source, "View Egress" once the shared drive
+    // is. It renders in a top and bottom bar, so target the first of each.
+    // Wait for the toggle to render (either label), then only click when Egress
+    // is still the source — clicking is a no-op (and a missing-button timeout)
+    // if the shared drive is already showing.
+    const viewShared = this.page
       .getByRole("button", { name: "View Shared Drive" })
-      .first()
-      .click();
+      .first();
+    const viewEgress = this.page
+      .getByRole("button", { name: "View Egress" })
+      .first();
+    await Promise.race([
+      viewShared.waitFor({ state: "visible", timeout: 30_000 }),
+      viewEgress.waitFor({ state: "visible", timeout: 30_000 }),
+    ]).catch(() => {});
+    if (await viewShared.isVisible().catch(() => false)) {
+      await viewShared.click();
+    }
   }
 
   async selectNetAppFiles(indices: number[]): Promise<void> {

--- a/e2e/pw/pages/getTransferMaterialsTab.ts
+++ b/e2e/pw/pages/getTransferMaterialsTab.ts
@@ -1,0 +1,20 @@
+import { Page } from "@playwright/test";
+import { loadEnvConfig } from "../helpers/env-config";
+import { TransferMaterialsTab } from "./TransferMaterialsTab";
+import { TransferMaterialsTabV1 } from "./TransferMaterialsTabV1";
+import { TransferMaterialsTabApi } from "./TransferMaterialsTabApi";
+
+export type { TransferMaterialsTabApi };
+
+/**
+ * Construct the Transfer Materials page object for the screen the target
+ * environment is running. Specs call this instead of `new TransferMaterialsTab`
+ * so they stay agnostic of which screen is active; the `TRANSFER_MATERIALS_V1`
+ * switch (see helpers/env-config.ts) decides.
+ */
+export function getTransferMaterialsTab(page: Page): TransferMaterialsTabApi {
+  const { transferMaterialsV1 } = loadEnvConfig();
+  return transferMaterialsV1
+    ? new TransferMaterialsTabV1(page)
+    : new TransferMaterialsTab(page);
+}

--- a/e2e/pw/pages/getTransferMaterialsTab.ts
+++ b/e2e/pw/pages/getTransferMaterialsTab.ts
@@ -7,10 +7,9 @@ import { TransferMaterialsTabApi } from "./TransferMaterialsTabApi";
 export type { TransferMaterialsTabApi };
 
 /**
- * Construct the Transfer Materials page object for the screen the target
- * environment is running. Specs call this instead of `new TransferMaterialsTab`
- * so they stay agnostic of which screen is active; the `TRANSFER_MATERIALS_V1`
- * switch (see helpers/env-config.ts) decides.
+ * Build the Transfer Materials page object for the active screen — the
+ * `TRANSFER_MATERIALS_V1` switch decides. Specs call this to stay
+ * screen-agnostic.
  */
 export function getTransferMaterialsTab(page: Page): TransferMaterialsTabApi {
   const { transferMaterialsV1 } = loadEnvConfig();

--- a/e2e/pw/tests/egress-to-netapp-copy-default.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-copy-default.spec.ts
@@ -56,7 +56,7 @@ test.describe("Egress to NetApp Copy (Default Mode)", () => {
     await transferTab.selectAction("Copy");
 
     // Step 5: Confirm transfer
-    await transferTab.confirmTransfer();
+    await transferTab.confirmTransfer("Copy");
 
     // Step 6: Wait for transfer to complete
     await transferTab.waitForTransferComplete();

--- a/e2e/pw/tests/egress-to-netapp-copy-default.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-copy-default.spec.ts
@@ -2,7 +2,7 @@ import { test } from "../fixtures/test-fixtures-default";
 import { CaseSearchPage } from "../pages/CaseSearchPage";
 import { SearchResultsPage } from "../pages/SearchResultsPage";
 import { CaseManagementPage } from "../pages/CaseManagementPage";
-import { TransferMaterialsTab } from "../pages/TransferMaterialsTab";
+import { getTransferMaterialsTab } from "../pages/getTransferMaterialsTab";
 import { ActivityLogTab } from "../pages/ActivityLogTab";
 
 test.describe("Egress to NetApp Copy (Default Mode)", () => {
@@ -28,7 +28,7 @@ test.describe("Egress to NetApp Copy (Default Mode)", () => {
     await caseMgmt.switchToTab("transfer-materials");
 
     // Step 4: Select files from Egress panel and initiate Copy
-    const transferTab = new TransferMaterialsTab(page);
+    const transferTab = getTransferMaterialsTab(page);
     await transferTab.waitForEgressFiles();
     await transferTab.navigateToFolder("4. Served Evidence");
     await transferTab.waitForEgressFiles();

--- a/e2e/pw/tests/egress-to-netapp-copy-large-default.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-copy-large-default.spec.ts
@@ -54,7 +54,7 @@ test.describe(`Egress to NetApp Copy - Large File ${fileSize}MB (Default Mode)`,
     await transferTab.selectAction("Copy");
 
     // Step 5: Confirm transfer
-    await transferTab.confirmTransfer();
+    await transferTab.confirmTransfer("Copy");
 
     // Step 6: Wait for transfer to complete (5 min timeout for large file)
     await transferTab.waitForTransferComplete(300_000);

--- a/e2e/pw/tests/egress-to-netapp-copy-large-default.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-copy-large-default.spec.ts
@@ -3,7 +3,7 @@ import { loadEnvConfig } from "../helpers/env-config";
 import { CaseSearchPage } from "../pages/CaseSearchPage";
 import { SearchResultsPage } from "../pages/SearchResultsPage";
 import { CaseManagementPage } from "../pages/CaseManagementPage";
-import { TransferMaterialsTab } from "../pages/TransferMaterialsTab";
+import { getTransferMaterialsTab } from "../pages/getTransferMaterialsTab";
 import { ActivityLogTab } from "../pages/ActivityLogTab";
 
 const fileSize = loadEnvConfig().largeTestFileSizeMb;
@@ -31,7 +31,7 @@ test.describe(`Egress to NetApp Copy - Large File ${fileSize}MB (Default Mode)`,
     await caseMgmt.switchToTab("transfer-materials");
 
     // Step 4: Select files from Egress panel and initiate Copy
-    const transferTab = new TransferMaterialsTab(page);
+    const transferTab = getTransferMaterialsTab(page);
     await transferTab.waitForEgressFiles();
     await transferTab.navigateToFolder("4. Served Evidence");
     await transferTab.waitForEgressFiles();

--- a/e2e/pw/tests/egress-to-netapp-copy-large.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-copy-large.spec.ts
@@ -2,7 +2,7 @@ import { test } from "../fixtures/test-fixtures-register-case";
 import { CaseSearchPage } from "../pages/CaseSearchPage";
 import { SearchResultsPage } from "../pages/SearchResultsPage";
 import { CaseManagementPage } from "../pages/CaseManagementPage";
-import { TransferMaterialsTab } from "../pages/TransferMaterialsTab";
+import { getTransferMaterialsTab } from "../pages/getTransferMaterialsTab";
 import { ActivityLogTab } from "../pages/ActivityLogTab";
 
 test.describe("Egress to NetApp Copy - Large File (200MB)", () => {
@@ -29,7 +29,7 @@ test.describe("Egress to NetApp Copy - Large File (200MB)", () => {
     await caseMgmt.switchToTab("transfer-materials");
 
     // Step 3: Select this test's uploaded file by name and initiate Copy
-    const transferTab = new TransferMaterialsTab(page);
+    const transferTab = getTransferMaterialsTab(page);
     await transferTab.waitForEgressFiles();
     await transferTab.navigateToFolder("4. Served Evidence");
     await transferTab.waitForEgressFiles();

--- a/e2e/pw/tests/egress-to-netapp-copy-large.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-copy-large.spec.ts
@@ -50,7 +50,7 @@ test.describe("Egress to NetApp Copy - Large File (200MB)", () => {
     await transferTab.selectAction("Copy");
 
     // Step 4: Confirm and wait for completion (5 min timeout for large file)
-    await transferTab.confirmTransfer();
+    await transferTab.confirmTransfer("Copy");
     await transferTab.waitForTransferComplete(300_000);
 
     // Step 5: Verify in Activity Log

--- a/e2e/pw/tests/egress-to-netapp-copy-multifile.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-copy-multifile.spec.ts
@@ -2,7 +2,7 @@ import { test } from "../fixtures/test-fixtures-register-case";
 import { CaseSearchPage } from "../pages/CaseSearchPage";
 import { SearchResultsPage } from "../pages/SearchResultsPage";
 import { CaseManagementPage } from "../pages/CaseManagementPage";
-import { TransferMaterialsTab } from "../pages/TransferMaterialsTab";
+import { getTransferMaterialsTab } from "../pages/getTransferMaterialsTab";
 import { ActivityLogTab } from "../pages/ActivityLogTab";
 
 test.describe("Egress to NetApp Copy - Multiple Files (10MB x 3)", () => {
@@ -29,7 +29,7 @@ test.describe("Egress to NetApp Copy - Multiple Files (10MB x 3)", () => {
     await caseMgmt.switchToTab("transfer-materials");
 
     // Step 3: Select this test's uploaded files by name and initiate Copy
-    const transferTab = new TransferMaterialsTab(page);
+    const transferTab = getTransferMaterialsTab(page);
     await transferTab.waitForEgressFiles();
     await transferTab.navigateToFolder("4. Served Evidence");
     await transferTab.waitForEgressFiles();

--- a/e2e/pw/tests/egress-to-netapp-copy-multifile.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-copy-multifile.spec.ts
@@ -55,7 +55,7 @@ test.describe("Egress to NetApp Copy - Multiple Files (10MB x 3)", () => {
     await transferTab.selectAction("Copy");
 
     // Step 4: Confirm and wait for completion
-    await transferTab.confirmTransfer();
+    await transferTab.confirmTransfer("Copy");
     await transferTab.waitForTransferComplete(300_000);
 
     // Step 5: Verify in Activity Log

--- a/e2e/pw/tests/egress-to-netapp-copy.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-copy.spec.ts
@@ -2,7 +2,7 @@ import { test } from "../fixtures/test-fixtures-register-case";
 import { CaseSearchPage } from "../pages/CaseSearchPage";
 import { SearchResultsPage } from "../pages/SearchResultsPage";
 import { CaseManagementPage } from "../pages/CaseManagementPage";
-import { TransferMaterialsTab } from "../pages/TransferMaterialsTab";
+import { getTransferMaterialsTab } from "../pages/getTransferMaterialsTab";
 import { ActivityLogTab } from "../pages/ActivityLogTab";
 
 test.describe("Egress to NetApp Copy", () => {
@@ -26,7 +26,7 @@ test.describe("Egress to NetApp Copy", () => {
     await caseMgmt.switchToTab("transfer-materials");
 
     // Step 3: Select this test's uploaded files by name and initiate Copy
-    const transferTab = new TransferMaterialsTab(page);
+    const transferTab = getTransferMaterialsTab(page);
     await transferTab.waitForEgressFiles();
     await transferTab.navigateToFolder("4. Served Evidence");
     await transferTab.waitForEgressFiles();

--- a/e2e/pw/tests/egress-to-netapp-copy.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-copy.spec.ts
@@ -42,7 +42,7 @@ test.describe("Egress to NetApp Copy", () => {
     await transferTab.selectAction("Copy");
 
     // Step 4: Confirm and wait for completion
-    await transferTab.confirmTransfer();
+    await transferTab.confirmTransfer("Copy");
     await transferTab.waitForTransferComplete();
 
     // Step 5: Verify in Activity Log

--- a/e2e/pw/tests/egress-to-netapp-move-default.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-move-default.spec.ts
@@ -2,7 +2,7 @@ import { test } from "../fixtures/test-fixtures-default";
 import { CaseSearchPage } from "../pages/CaseSearchPage";
 import { SearchResultsPage } from "../pages/SearchResultsPage";
 import { CaseManagementPage } from "../pages/CaseManagementPage";
-import { TransferMaterialsTab } from "../pages/TransferMaterialsTab";
+import { getTransferMaterialsTab } from "../pages/getTransferMaterialsTab";
 import { ActivityLogTab } from "../pages/ActivityLogTab";
 
 test.describe("Egress to NetApp Move (Default Mode)", () => {
@@ -28,7 +28,7 @@ test.describe("Egress to NetApp Move (Default Mode)", () => {
     await caseMgmt.switchToTab("transfer-materials");
 
     // Step 4: Select files from Egress panel and initiate Move
-    const transferTab = new TransferMaterialsTab(page);
+    const transferTab = getTransferMaterialsTab(page);
     await transferTab.waitForEgressFiles();
     await transferTab.navigateToFolder("4. Served Evidence");
     await transferTab.waitForEgressFiles();

--- a/e2e/pw/tests/egress-to-netapp-move-default.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-move-default.spec.ts
@@ -57,7 +57,7 @@ test.describe("Egress to NetApp Move (Default Mode)", () => {
     await transferTab.selectAction("Move");
 
     // Step 5: Confirm transfer
-    await transferTab.confirmTransfer();
+    await transferTab.confirmTransfer("Move");
 
     // Step 6: Wait for transfer to complete
     await transferTab.waitForTransferComplete();

--- a/e2e/pw/tests/egress-to-netapp-move.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-move.spec.ts
@@ -2,7 +2,7 @@ import { test } from "../fixtures/test-fixtures-register-case";
 import { CaseSearchPage } from "../pages/CaseSearchPage";
 import { SearchResultsPage } from "../pages/SearchResultsPage";
 import { CaseManagementPage } from "../pages/CaseManagementPage";
-import { TransferMaterialsTab } from "../pages/TransferMaterialsTab";
+import { getTransferMaterialsTab } from "../pages/getTransferMaterialsTab";
 import { ActivityLogTab } from "../pages/ActivityLogTab";
 
 test.describe("Egress to NetApp Move", () => {
@@ -29,7 +29,7 @@ test.describe("Egress to NetApp Move", () => {
     await caseMgmt.switchToTab("transfer-materials");
 
     // Step 3: Select this test's uploaded files by name and initiate Move
-    const transferTab = new TransferMaterialsTab(page);
+    const transferTab = getTransferMaterialsTab(page);
     await transferTab.waitForEgressFiles();
     await transferTab.navigateToFolder("4. Served Evidence");
     await transferTab.waitForEgressFiles();

--- a/e2e/pw/tests/egress-to-netapp-move.spec.ts
+++ b/e2e/pw/tests/egress-to-netapp-move.spec.ts
@@ -45,7 +45,7 @@ test.describe("Egress to NetApp Move", () => {
     await transferTab.selectAction("Move");
 
     // Step 4: Confirm and wait for completion
-    await transferTab.confirmTransfer();
+    await transferTab.confirmTransfer("Move");
     await transferTab.waitForTransferComplete();
 
     // Step 5: Verify in Activity Log

--- a/e2e/pw/tests/login-only.spec.ts
+++ b/e2e/pw/tests/login-only.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect } from "../fixtures/test-fixtures-register-case";
+import { test } from "../fixtures/test-fixtures-register-case";
 import { CaseSearchPage } from "../pages/CaseSearchPage";
 import { SearchResultsPage } from "../pages/SearchResultsPage";
 import { CaseManagementPage } from "../pages/CaseManagementPage";
-import { TransferMaterialsTab } from "../pages/TransferMaterialsTab";
+import { getTransferMaterialsTab } from "../pages/getTransferMaterialsTab";
 import { ActivityLogTab } from "../pages/ActivityLogTab";
 
 test.describe("Full-flow smoke", () => {
@@ -27,7 +27,7 @@ test.describe("Full-flow smoke", () => {
     const caseMgmt = new CaseManagementPage(page);
     await caseMgmt.waitForLoad();
 
-    const transferTab = new TransferMaterialsTab(page);
+    const transferTab = getTransferMaterialsTab(page);
     await transferTab.waitForEgressFiles();
     await transferTab.navigateToFolder("4. Served Evidence");
     await transferTab.waitForEgressFiles();
@@ -50,11 +50,10 @@ test.describe("Full-flow smoke", () => {
     await transferTab.confirmTransfer();
     await transferTab.waitForTransferComplete();
 
-    // Step 3: Verify file shows up in NetApp destination panel
-    const fileName = files[0].fileName;
-    const netappTable = page.getByTestId("netapp-table-wrapper");
-    await expect(netappTable).toBeVisible({ timeout: 30_000 });
-    await expect(netappTable).toContainText(fileName, { timeout: 30_000 });
+    // Step 3: Verify file shows up in NetApp destination panel. Screen-
+    // agnostic: the old screen checks the always-visible NetApp panel in
+    // place; the new screen switches to the shared-drive source first.
+    await transferTab.verifyNetAppContainsFile(files[0].fileName);
 
     // Step 4: Verify Activity Log entry
     await caseMgmt.switchToTab("activity-log");

--- a/e2e/pw/tests/login-only.spec.ts
+++ b/e2e/pw/tests/login-only.spec.ts
@@ -50,9 +50,7 @@ test.describe("Full-flow smoke", () => {
     await transferTab.confirmTransfer();
     await transferTab.waitForTransferComplete();
 
-    // Step 3: Verify file shows up in NetApp destination panel. Screen-
-    // agnostic: the old screen checks the always-visible NetApp panel in
-    // place; the new screen switches to the shared-drive source first.
+    // Step 3: Verify file landed in the NetApp panel (screen-agnostic).
     await transferTab.verifyNetAppContainsFile(files[0].fileName);
 
     // Step 4: Verify Activity Log entry

--- a/e2e/pw/tests/login-only.spec.ts
+++ b/e2e/pw/tests/login-only.spec.ts
@@ -43,7 +43,7 @@ test.describe("Full-flow smoke", () => {
       files[0].fileName,
       uploadSubfolder
         ? ["4. Served Evidence", uploadSubfolder]
-        : ["4. Served Evidence"]
+        : ["4. Served Evidence"],
     );
     await transferTab.selectAllEgressFiles();
     await transferTab.selectAction("Copy");

--- a/e2e/pw/tests/login-only.spec.ts
+++ b/e2e/pw/tests/login-only.spec.ts
@@ -47,7 +47,7 @@ test.describe("Full-flow smoke", () => {
     );
     await transferTab.selectAllEgressFiles();
     await transferTab.selectAction("Copy");
-    await transferTab.confirmTransfer();
+    await transferTab.confirmTransfer("Copy");
     await transferTab.waitForTransferComplete();
 
     // Step 3: Verify file landed in the NetApp panel (screen-agnostic).

--- a/e2e/pw/tests/netapp-to-egress-copy-default.spec.ts
+++ b/e2e/pw/tests/netapp-to-egress-copy-default.spec.ts
@@ -59,7 +59,7 @@ test.describe("NetApp to Egress Copy (Default Mode)", () => {
         await transferTab.waitForEgressFiles();
       }
       await transferTab.selectReverseAction("Copy");
-      await transferTab.confirmTransfer();
+      await transferTab.confirmTransfer("Copy");
     }
     await transferTab.waitForTransferComplete();
 

--- a/e2e/pw/tests/netapp-to-egress-copy-default.spec.ts
+++ b/e2e/pw/tests/netapp-to-egress-copy-default.spec.ts
@@ -45,7 +45,7 @@ test.describe("NetApp to Egress Copy (Default Mode)", () => {
     if (loadEnvConfig().transferMaterialsV1) {
       // New screen: no second panel — Copy selected navigates to the
       // destination-tree page where the target folder is chosen.
-      await transferTab.selectReverseAction("Copy");
+      await transferTab.selectAction("Copy", "netAppToEgress");
       await new TransferDestinationPage(page).chooseFolder("Copy", [
         "2. Counsel only",
         uploadSubfolder!,
@@ -58,7 +58,7 @@ test.describe("NetApp to Egress Copy (Default Mode)", () => {
         await transferTab.navigateToFolder(uploadSubfolder);
         await transferTab.waitForEgressFiles();
       }
-      await transferTab.selectReverseAction("Copy");
+      await transferTab.selectAction("Copy", "netAppToEgress");
       await transferTab.confirmTransfer("Copy");
     }
     await transferTab.waitForTransferComplete();

--- a/e2e/pw/tests/netapp-to-egress-copy-default.spec.ts
+++ b/e2e/pw/tests/netapp-to-egress-copy-default.spec.ts
@@ -2,8 +2,10 @@ import { test } from "../fixtures/test-fixtures-default";
 import { CaseSearchPage } from "../pages/CaseSearchPage";
 import { SearchResultsPage } from "../pages/SearchResultsPage";
 import { CaseManagementPage } from "../pages/CaseManagementPage";
-import { TransferMaterialsTab } from "../pages/TransferMaterialsTab";
+import { getTransferMaterialsTab } from "../pages/getTransferMaterialsTab";
+import { TransferDestinationPage } from "../pages/TransferDestinationPage";
 import { ActivityLogTab } from "../pages/ActivityLogTab";
+import { loadEnvConfig } from "../helpers/env-config";
 import { NETAPP_FIXTURE_FILENAME } from "../helpers/constants";
 
 test.describe("NetApp to Egress Copy (Default Mode)", () => {
@@ -25,7 +27,7 @@ test.describe("NetApp to Egress Copy (Default Mode)", () => {
     await caseMgmt.waitForLoad();
     await caseMgmt.switchToTab("transfer-materials");
 
-    const transferTab = new TransferMaterialsTab(page);
+    const transferTab = getTransferMaterialsTab(page);
     await transferTab.waitForEgressFiles();
     await transferTab.waitForNetAppFiles();
 
@@ -40,15 +42,25 @@ test.describe("NetApp to Egress Copy (Default Mode)", () => {
 
     // Egress destination — different parent folder than upload source,
     // per-run timestamped subfolder so repeat runs never collide.
-    await transferTab.navigateToFolder("2. Counsel only");
-    await transferTab.waitForEgressFiles();
-    if (uploadSubfolder) {
-      await transferTab.navigateToFolder(uploadSubfolder);
+    if (loadEnvConfig().transferMaterialsV1) {
+      // New screen: no second panel — Copy selected navigates to the
+      // destination-tree page where the target folder is chosen.
+      await transferTab.selectReverseAction("Copy");
+      await new TransferDestinationPage(page).chooseFolder("Copy", [
+        "2. Counsel only",
+        uploadSubfolder!,
+      ]);
+    } else {
+      // Old screen: navigate the Egress panel to the destination, then confirm.
+      await transferTab.navigateToFolder("2. Counsel only");
       await transferTab.waitForEgressFiles();
+      if (uploadSubfolder) {
+        await transferTab.navigateToFolder(uploadSubfolder);
+        await transferTab.waitForEgressFiles();
+      }
+      await transferTab.selectReverseAction("Copy");
+      await transferTab.confirmTransfer();
     }
-
-    await transferTab.selectReverseAction("Copy");
-    await transferTab.confirmTransfer();
     await transferTab.waitForTransferComplete();
 
     await caseMgmt.switchToTab("activity-log");

--- a/e2e/pw/tests/netapp-to-egress-copy.spec.ts
+++ b/e2e/pw/tests/netapp-to-egress-copy.spec.ts
@@ -67,7 +67,7 @@ test.describe("NetApp to Egress Copy", () => {
         await transferTab.waitForEgressFiles();
       }
       await transferTab.selectReverseAction("Copy");
-      await transferTab.confirmTransfer();
+      await transferTab.confirmTransfer("Copy");
     }
     await transferTab.waitForTransferComplete();
 

--- a/e2e/pw/tests/netapp-to-egress-copy.spec.ts
+++ b/e2e/pw/tests/netapp-to-egress-copy.spec.ts
@@ -53,7 +53,7 @@ test.describe("NetApp to Egress Copy", () => {
     if (loadEnvConfig().transferMaterialsV1) {
       // New screen: no second panel — Copy selected navigates to the
       // destination-tree page where the target folder is chosen.
-      await transferTab.selectReverseAction("Copy");
+      await transferTab.selectAction("Copy", "netAppToEgress");
       await new TransferDestinationPage(page).chooseFolder("Copy", [
         "2. Counsel only",
         uploadSubfolder!,
@@ -66,7 +66,7 @@ test.describe("NetApp to Egress Copy", () => {
         await transferTab.navigateToFolder(uploadSubfolder);
         await transferTab.waitForEgressFiles();
       }
-      await transferTab.selectReverseAction("Copy");
+      await transferTab.selectAction("Copy", "netAppToEgress");
       await transferTab.confirmTransfer("Copy");
     }
     await transferTab.waitForTransferComplete();

--- a/e2e/pw/tests/netapp-to-egress-copy.spec.ts
+++ b/e2e/pw/tests/netapp-to-egress-copy.spec.ts
@@ -1,8 +1,10 @@
 import { test } from "../fixtures/test-fixtures-register-case";
+import { loadEnvConfig } from "../helpers/env-config";
 import { CaseSearchPage } from "../pages/CaseSearchPage";
 import { SearchResultsPage } from "../pages/SearchResultsPage";
 import { CaseManagementPage } from "../pages/CaseManagementPage";
-import { TransferMaterialsTab } from "../pages/TransferMaterialsTab";
+import { getTransferMaterialsTab } from "../pages/getTransferMaterialsTab";
+import { TransferDestinationPage } from "../pages/TransferDestinationPage";
 import { ActivityLogTab } from "../pages/ActivityLogTab";
 
 test.describe("NetApp to Egress Copy", () => {
@@ -28,7 +30,7 @@ test.describe("NetApp to Egress Copy", () => {
     await caseMgmt.waitForLoad();
     await caseMgmt.switchToTab("transfer-materials");
 
-    const transferTab = new TransferMaterialsTab(page);
+    const transferTab = getTransferMaterialsTab(page);
     await transferTab.waitForEgressFiles();
     await transferTab.waitForNetAppFiles();
 
@@ -40,30 +42,33 @@ test.describe("NetApp to Egress Copy", () => {
     // Pre-condition: REGISTER_CASE_NETAPP_FOLDER must contain >=1 file.
     // Source identity doesn't matter — destination is a fresh per-run
     // workspace, no collisions. See README "NetApp source pre-condition".
-    const dateHeader = page
-      .getByTestId("netapp-table-wrapper")
-      .getByRole("button", { name: "Last modified date" });
-    await dateHeader.click();
-    await transferTab.waitForNetAppFiles();
-    await dateHeader.click();
-    await transferTab.waitForNetAppFiles();
+    await transferTab.sortNetAppByDateDescending();
 
     await transferTab.selectNetAppFiles([0]);
 
-    // Step 5: Navigate into Egress destination subfolder.
-    // Use a different top-level folder than the upload source (4. Served
-    // Evidence), then into this test's dated subfolder so repeat runs don't
-    // collide with files already copied there on previous runs.
-    await transferTab.navigateToFolder("2. Counsel only");
-    await transferTab.waitForEgressFiles();
-    if (uploadSubfolder) {
-      await transferTab.navigateToFolder(uploadSubfolder);
+    // Step 5+6: Initiate Copy to an Egress destination subfolder. The
+    // destination is "2. Counsel only" -> this run's dated subfolder (a
+    // different top-level folder than the "4. Served Evidence" source, so
+    // repeat runs don't collide).
+    if (loadEnvConfig().transferMaterialsV1) {
+      // New screen: no second panel — Copy selected navigates to the
+      // destination-tree page where the target folder is chosen.
+      await transferTab.selectReverseAction("Copy");
+      await new TransferDestinationPage(page).chooseFolder("Copy", [
+        "2. Counsel only",
+        uploadSubfolder!,
+      ]);
+    } else {
+      // Old screen: navigate the Egress panel to the destination, then confirm.
+      await transferTab.navigateToFolder("2. Counsel only");
       await transferTab.waitForEgressFiles();
+      if (uploadSubfolder) {
+        await transferTab.navigateToFolder(uploadSubfolder);
+        await transferTab.waitForEgressFiles();
+      }
+      await transferTab.selectReverseAction("Copy");
+      await transferTab.confirmTransfer();
     }
-
-    // Step 6: Initiate Copy to Egress
-    await transferTab.selectReverseAction("Copy");
-    await transferTab.confirmTransfer();
     await transferTab.waitForTransferComplete();
 
     // Step 7: Verify in Activity Log

--- a/e2e/pw/tests/seed-netapp-fixture.setup.ts
+++ b/e2e/pw/tests/seed-netapp-fixture.setup.ts
@@ -34,7 +34,7 @@ const SEED_SIZE_MB = 1;
 setup("seed lcc-e2e-fixture-source.txt to NetApp", async ({ page }) => {
   setup.skip(
     !process.env.RUN_SEED,
-    "Opt-in seed — run with RUN_SEED=1 npx playwright test --project=seed-netapp-fixture"
+    "Opt-in seed — run with RUN_SEED=1 npx playwright test --project=seed-netapp-fixture",
   );
   setup.setTimeout(300_000);
 
@@ -49,14 +49,14 @@ setup("seed lcc-e2e-fixture-source.txt to NetApp", async ({ page }) => {
   console.log("Authenticating with Egress + uploading seed source...");
   const egressToken = await authenticateEgress(
     config.egressBaseUrl,
-    config.egressServiceAccountAuth
+    config.egressServiceAccountAuth,
   );
   await createFolder(
     config.egressBaseUrl,
     egressToken,
     config.defaultWorkspaceId,
     SEED_PARENT,
-    SEED_SUBFOLDER
+    SEED_SUBFOLDER,
   );
   const uploaded = await uploadFile(
     config.egressBaseUrl,
@@ -64,7 +64,7 @@ setup("seed lcc-e2e-fixture-source.txt to NetApp", async ({ page }) => {
     config.defaultWorkspaceId,
     SEED_SIZE_MB * 1024 * 1024,
     NETAPP_FIXTURE_FILENAME,
-    `${SEED_PARENT}/${SEED_SUBFOLDER}/`
+    `${SEED_PARENT}/${SEED_SUBFOLDER}/`,
   );
 
   console.log("Logging in via browser...");
@@ -106,7 +106,7 @@ setup("seed lcc-e2e-fixture-source.txt to NetApp", async ({ page }) => {
     const message = err instanceof Error ? err.message : String(err);
     if (/files? already exist/i.test(message)) {
       console.log(
-        `Fixture already present at <NetApp>/${NETAPP_FIXTURE_FILENAME} — seed is a no-op.`
+        `Fixture already present at <NetApp>/${NETAPP_FIXTURE_FILENAME} — seed is a no-op.`,
       );
     } else {
       throw err;
@@ -129,7 +129,7 @@ setup("seed lcc-e2e-fixture-source.txt to NetApp", async ({ page }) => {
   // would otherwise silently "succeed" while the default test fails
   // with a fixture-missing error.
   console.log(
-    `Verifying fixture is selectable from NetApp root by exact name...`
+    `Verifying fixture is selectable from NetApp root by exact name...`,
   );
   await transferTab.switchToNetAppSource();
   await transferTab.waitForNetAppFiles();
@@ -142,11 +142,11 @@ setup("seed lcc-e2e-fixture-source.txt to NetApp", async ({ page }) => {
       config.egressBaseUrl,
       egressToken,
       config.defaultWorkspaceId,
-      [uploaded.id]
+      [uploaded.id],
     );
   }
 
   console.log(
-    `\n=== Done ===\nFixture seeded at: <NetApp>/${NETAPP_FIXTURE_FILENAME}`
+    `\n=== Done ===\nFixture seeded at: <NetApp>/${NETAPP_FIXTURE_FILENAME}`,
   );
 });

--- a/e2e/pw/tests/seed-netapp-fixture.setup.ts
+++ b/e2e/pw/tests/seed-netapp-fixture.setup.ts
@@ -113,14 +113,9 @@ setup("seed lcc-e2e-fixture-source.txt to NetApp", async ({ page }) => {
     }
   }
 
-  // The new screen leaves the transfer-materials view after a transfer
-  // attempt: a duplicate-file rejection lands on the transfer-errors
-  // route, and a successful transfer lands back on case management with
-  // the success banner. Either way the "View Shared Drive" toggle is
-  // gone, so return to case management and re-enter the Transfer
-  // Materials tab before verifying. On the old screen the view is
-  // retained, so `dismissTransferErrorIfPresent` is a no-op and
-  // re-selecting the tab is harmless.
+  // A transfer attempt leaves the transfer-materials view (error route on a
+  // duplicate rejection; case management on success), so return there and
+  // re-enter the tab before verifying. Harmless on the old screen.
   await transferTab.dismissTransferErrorIfPresent();
   await caseMgmt.waitForLoad();
   await caseMgmt.switchToTab("transfer-materials");

--- a/e2e/pw/tests/seed-netapp-fixture.setup.ts
+++ b/e2e/pw/tests/seed-netapp-fixture.setup.ts
@@ -10,7 +10,7 @@ import { browserLogin } from "../fixtures/setup-helper";
 import { CaseSearchPage } from "../pages/CaseSearchPage";
 import { SearchResultsPage } from "../pages/SearchResultsPage";
 import { CaseManagementPage } from "../pages/CaseManagementPage";
-import { TransferMaterialsTab } from "../pages/TransferMaterialsTab";
+import { getTransferMaterialsTab } from "../pages/getTransferMaterialsTab";
 import { NETAPP_FIXTURE_FILENAME } from "../helpers/constants";
 
 // One-shot seed: puts the canonical NetApp source fixture at
@@ -82,7 +82,7 @@ setup("seed lcc-e2e-fixture-source.txt to NetApp", async ({ page }) => {
   await caseMgmt.waitForLoad();
   await caseMgmt.switchToTab("transfer-materials");
 
-  const transferTab = new TransferMaterialsTab(page);
+  const transferTab = getTransferMaterialsTab(page);
   await transferTab.waitForEgressFiles();
   await transferTab.navigateToFolder(SEED_PARENT);
   await transferTab.waitForEgressFiles();
@@ -112,6 +112,19 @@ setup("seed lcc-e2e-fixture-source.txt to NetApp", async ({ page }) => {
       throw err;
     }
   }
+
+  // The new screen leaves the transfer-materials view after a transfer
+  // attempt: a duplicate-file rejection lands on the transfer-errors
+  // route, and a successful transfer lands back on case management with
+  // the success banner. Either way the "View Shared Drive" toggle is
+  // gone, so return to case management and re-enter the Transfer
+  // Materials tab before verifying. On the old screen the view is
+  // retained, so `dismissTransferErrorIfPresent` is a no-op and
+  // re-selecting the tab is harmless.
+  await transferTab.dismissTransferErrorIfPresent();
+  await caseMgmt.waitForLoad();
+  await caseMgmt.switchToTab("transfer-materials");
+  await transferTab.waitForEgressFiles();
 
   // Verify the fixture is at the path the default-mode spec actually
   // selects from — i.e. selectable by exact basename at NetApp source

--- a/e2e/pw/tests/seed-netapp-fixture.setup.ts
+++ b/e2e/pw/tests/seed-netapp-fixture.setup.ts
@@ -95,7 +95,7 @@ setup("seed lcc-e2e-fixture-source.txt to NetApp", async ({ page }) => {
   ]);
   await transferTab.selectEgressFileByName(NETAPP_FIXTURE_FILENAME);
   await transferTab.selectAction("Copy");
-  await transferTab.confirmTransfer();
+  await transferTab.confirmTransfer("Copy");
 
   // Idempotent: if the fixture is already on NetApp, the UI's pre-flight
   // rejects the transfer with "Some files already exist in the destination


### PR DESCRIPTION
  Adding  `TRANSFER_MATERIALS_V1` switch to the `e2e/pw` suite so it    
  drives the redesigned (v1) Transfer Materials screen when the flag is on and the  old screen when off — keeping the old screen covered during rollout and adding  
  new-screen
  coverage, without two suites fighting over selectors.

  - Screen-agnostic `TransferMaterialsTabApi` contract;
  `getTransferMaterialsTab`
    picks `TransferMaterialsTab` (old) or `TransferMaterialsTabV1`     
  (new) from the flag,
    so specs never reference a screen-specific selector.
  - New-screen page objects: `TransferMaterialsTabV1` +
  `TransferDestinationPage`
    (folder-tree confirm — no modal). Covers the "shared drive" table  
  ids,
    `Copy selected` / `Move selected`, the `View Shared Drive` / `View 
  Egress`
    toggle, and the new `transfer-errors` /
  `transfer-permissions-error` /
    `transfer-resolve-file-path` routes.
  - Recover from the shared full-page transfer error (both screens) so 
  the seed can
    re-enter the tab.
  - README: how the flag reaches the environment (SPA build flag +     
  private-beta
    group), corrected register-case file sizes, and the
  page-object-layer notes.

  ## Testing
  Ran the full `e2e/pw` suite locally against dev on both screens:     
  - **New UI:** existing-case 4/4, register-case 8/8
  - **Old UI:** existing-case 4/4, register-case 8/8


