### PR TITLE
fix: egress search with space

### DIFF
--- a/backend/CPS.ComplexCases.Egress.Tests/Unit/EgressRequestFactoryTests.cs
+++ b/backend/CPS.ComplexCases.Egress.Tests/Unit/EgressRequestFactoryTests.cs
@@ -1,0 +1,52 @@
+using CPS.ComplexCases.Egress.Factories;
+using CPS.ComplexCases.Egress.Models.Args;
+
+namespace CPS.ComplexCases.Egress.Tests.Unit;
+
+public class EgressRequestFactoryTests
+{
+  private readonly EgressRequestFactory _sut = new();
+
+  [Theory]
+  [InlineData("Op Test", "Op%20Test")]
+  [InlineData("Op&Test", "Op%26Test")]
+  [InlineData("Op=Test", "Op%3DTest")]
+  [InlineData("Op+Test", "Op%2BTest")]
+  [InlineData("Op/Test", "Op%2FTest")]
+  [InlineData("Op?Test", "Op%3FTest")]
+  [InlineData("Op#Test", "Op%23Test")]
+  public void ListWorkspacesRequest_WhenNameContainsReservedCharacters_PercentEncodesNameInQueryString(
+    string name,
+    string expectedEncodedName)
+  {
+    var arg = new ListEgressWorkspacesArg
+    {
+      Skip = 0,
+      Take = 10,
+      Name = name
+    };
+
+    using var request = _sut.ListWorkspacesRequest(arg, "token");
+
+    Assert.Equal(
+      $"/api/v1/workspaces?view=full&skip=0&limit=10&name={expectedEncodedName}",
+      request.RequestUri?.ToString());
+  }
+
+  [Fact]
+  public void ListWorkspacesRequest_WhenNameIsNull_OmitsNameQueryParameter()
+  {
+    var arg = new ListEgressWorkspacesArg
+    {
+      Skip = 5,
+      Take = 25,
+      Name = null
+    };
+
+    using var request = _sut.ListWorkspacesRequest(arg, "token");
+
+    Assert.Equal(
+      "/api/v1/workspaces?view=full&skip=5&limit=25",
+      request.RequestUri?.ToString());
+  }
+}

--- a/backend/CPS.ComplexCases.Egress/Factories/EgressRequestFactory.cs
+++ b/backend/CPS.ComplexCases.Egress/Factories/EgressRequestFactory.cs
@@ -21,7 +21,7 @@ public class EgressRequestFactory : IEgressRequestFactory
 
     if (!string.IsNullOrEmpty(arg.Name))
     {
-      relativeUrl.Append($"&name={arg.Name}");
+      relativeUrl.Append($"&name={Uri.EscapeDataString(arg.Name)}");
     }
 
     var request = new HttpRequestMessage(HttpMethod.Get, relativeUrl.ToString());


### PR DESCRIPTION
# PR checklist

Tick what applies before you raise. Delete anything that doesn't.

## Correctness
- [x] Does what the ticket asks for
- [x] Handles the edge cases (empty, null, zero, large inputs), not just the happy path
- [x] Errors are handled, not swallowed
- [x] New logic has tests, including the failure cases
- [x] Tests assert something real, not just run the code

## Keeping it simple
- [x] Doesn't rebuild something that already exists in the codebase
- [x] No more complex or slower than it needs to be
- [x] No leftover debug logging or commented-out code

## Easy to miss (a green pipeline won't flag these)
- [x] One logical change, not a pile of unrelated stuff

### If you touched the backend
- [x] Schema changes have a migration, and the Down() doesn't drop anything it shouldn't
- [x] New app settings are wired into the fa-config templates
- [x] Secrets use Key Vault references, not plain text
- [x] New outbound HTTP clients go through the shared resilience handler (AddResiliencePolicyHandler), rather than hand-rolling retries
- [x] New calls to an external service (DDEI, Egress, NetApp) have client tests against a WireMock stub (for the serialisation, auth and error handling) and are covered by the integration tests that run against the real dev services
- [x] Ran dotnet format, since CI builds and tests but doesn't check formatting
