### PR TITLE
fix: path validation issue

### DIFF
--- a/backend/CPS.ComplexCases.Common/Models/Domain/FileTransferFailedInfo.cs
+++ b/backend/CPS.ComplexCases.Common/Models/Domain/FileTransferFailedInfo.cs
@@ -6,5 +6,5 @@ public class FileTransferFailedInfo : FileTransferInfo
 {
     public string Message { get; set; } = string.Empty;
     public TransferFailedType ErrorType { get; set; }
-    public string? DestinationFullPath { get; set; }
+    public string DestinationFullPath { get; set; } = string.Empty;
 }

--- a/backend/CPS.ComplexCases.Common/Models/Domain/FileTransferFailedInfo.cs
+++ b/backend/CPS.ComplexCases.Common/Models/Domain/FileTransferFailedInfo.cs
@@ -6,4 +6,5 @@ public class FileTransferFailedInfo : FileTransferInfo
 {
     public string Message { get; set; } = string.Empty;
     public TransferFailedType ErrorType { get; set; }
+    public string? DestinationFullPath { get; set; }
 }

--- a/backend/CPS.ComplexCases.FileTransfer.API.Tests/Unit/Functions/ListFilesForTransferTests.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API.Tests/Unit/Functions/ListFilesForTransferTests.cs
@@ -180,6 +180,7 @@ public class ListFilesForTransferTests
         Assert.Equal(TransferFailedType.PathLengthExceeded, error.ErrorType);
         Assert.Equal(expectedErrorMessage, error.Message);
         Assert.Equal(sourcePath, error.SourcePath);
+        Assert.Equal($"{destinationPath}/{sourcePath}", error.DestinationFullPath);
     }
 
     [Fact]

--- a/backend/CPS.ComplexCases.FileTransfer.API/Functions/ListFilesForTransfer.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Functions/ListFilesForTransfer.cs
@@ -120,6 +120,7 @@ public class ListFilesForTransfer(
                         Id = file.Id,
                         SourcePath = file.SourcePath,
                         RelativePath = file.RelativePath,
+                        DestinationFullPath = fullDestinationPath,
                         Message = string.Join("; ", validationResult.Errors.Select(e => e.ErrorMessage)),
                         ErrorType = TransferFailedType.PathLengthExceeded
                     });

--- a/ui-spa/playwright/integration-tests/transfer-material-v0/egress-netapp-transfer-indexing-error.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-material-v0/egress-netapp-transfer-indexing-error.spec.ts
@@ -123,12 +123,16 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
                   id: "id_3",
                   sourcePath:
                     "egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_5",
                   sourcePath:
                     "egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
                   errorType: "",
                 },
               ],
@@ -257,6 +261,9 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
       await expect(page.getByTestId("character-tag")).toHaveText(
         "257 characters",
       );
+      await expect(
+        page.getByText("You must reduce this to 260 characters or fewer."),
+      ).not.toBeVisible();
 
       await page.getByRole("button", { name: "Continue" }).click();
       await expect(page).toHaveURL(
@@ -326,6 +333,9 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
       await expect(page.getByTestId("character-tag")).toHaveText(
         "260 characters",
       );
+      await expect(
+        page.getByText("You must reduce this to 260 characters or fewer."),
+      ).not.toBeVisible();
 
       await page.getByRole("button", { name: "Continue" }).click();
       await expect(page).toHaveURL(
@@ -359,6 +369,14 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
       await expect(
         page.getByTestId("resolve-path-success-notification-banner"),
       ).toBeVisible();
+      await expect(
+        page.getByRole("heading", {
+          name: "File paths are too long to transfer",
+        }),
+      ).not.toBeVisible();
+      await expect(
+        page.getByTestId("resolve-file-path-inset-text"),
+      ).not.toBeVisible();
       await expect(
         page.getByTestId("resolve-path-success-notification-banner"),
       ).toContainText("Success");
@@ -441,12 +459,16 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
                   id: "id_3",
                   sourcePath:
                     "egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_5",
                   sourcePath:
                     "egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
                   errorType: "",
                 },
               ],
@@ -523,12 +545,16 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
                   id: "id_3",
                   sourcePath:
                     "egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_5",
                   sourcePath:
                     "egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
                   errorType: "",
                 },
               ],
@@ -623,36 +649,48 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
                   id: "id_6",
                   sourcePath:
                     "file6qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/file6qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_6_1",
                   sourcePath:
                     "file6_1qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/file6_1qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_3",
                   sourcePath:
                     "egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_3_1",
                   sourcePath:
                     "egress/folder3/file3_1qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder3/file3_1qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_5",
                   sourcePath:
                     "egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_5_1",
                   sourcePath:
                     "egress/folder4/folder5/file5_1qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder4/folder5/file5_1qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
                   errorType: "",
                 },
               ],

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer-indexing-error.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer-indexing-error.spec.ts
@@ -138,12 +138,16 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
                   id: "id_3",
                   sourcePath:
                     "egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_5",
                   sourcePath:
                     "egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
                   errorType: "",
                 },
               ],
@@ -272,6 +276,9 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
       await expect(page.getByTestId("character-tag")).toHaveText(
         "257 characters",
       );
+      await expect(
+        page.getByText("You must reduce this to 260 characters or fewer."),
+      ).not.toBeVisible();
 
       await page.getByRole("button", { name: "Continue" }).click();
       await expect(page).toHaveURL(
@@ -341,6 +348,9 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
       await expect(page.getByTestId("character-tag")).toHaveText(
         "260 characters",
       );
+      await expect(
+        page.getByText("You must reduce this to 260 characters or fewer."),
+      ).not.toBeVisible();
 
       await page.getByRole("button", { name: "Continue" }).click();
       await expect(page).toHaveURL(
@@ -374,6 +384,14 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
       await expect(
         page.getByTestId("resolve-path-success-notification-banner"),
       ).toBeVisible();
+      await expect(
+        page.getByRole("heading", {
+          name: "File paths are too long to transfer",
+        }),
+      ).not.toBeVisible();
+      await expect(
+        page.getByTestId("resolve-file-path-inset-text"),
+      ).not.toBeVisible();
       await expect(
         page.getByTestId("resolve-path-success-notification-banner"),
       ).toContainText("Success");
@@ -471,12 +489,16 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
                   id: "id_3",
                   sourcePath:
                     "egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_5",
                   sourcePath:
                     "egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
                   errorType: "",
                 },
               ],
@@ -556,12 +578,16 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
                   id: "id_3",
                   sourcePath:
                     "egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_5",
                   sourcePath:
                     "egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
                   errorType: "",
                 },
               ],
@@ -656,36 +682,48 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
                   id: "id_6",
                   sourcePath:
                     "file6qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/file6qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_6_1",
                   sourcePath:
                     "file6_1qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/file6_1qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_3",
                   sourcePath:
                     "egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_3_1",
                   sourcePath:
                     "egress/folder3/file3_1qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder3/file3_1qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_5",
                   sourcePath:
                     "egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
                   errorType: "",
                 },
                 {
                   id: "id_5_1",
                   sourcePath:
                     "egress/folder4/folder5/file5_1qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
+                  destinationFullPath:
+                    "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder4/folder5/file5_1qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
                   errorType: "",
                 },
               ],

--- a/ui-spa/src/common/utils/getMappedResolvePathFiles.test.ts
+++ b/ui-spa/src/common/utils/getMappedResolvePathFiles.test.ts
@@ -53,4 +53,38 @@ describe("getMappedResolvePathFiles", () => {
     const result = getMappedResolvePathFiles(indexingErrors, "destination/");
     expect(result).toEqual(expectedResult);
   });
+
+  it("Should prefer destinationFullPath for display path length", () => {
+    const longDirectory =
+      "\\\\cps-fileshare\\netapp01\\Area Shares\\CCU Manchester\\Op Milton\\1. Incoming Master Copy\\17. Egress 160726\\Billing data for all suspects\\Billing data\\" +
+      "a".repeat(100);
+    const fileName = "CP_0000_TEST_billing_summary.xlsx";
+    const destinationFullPath = `${longDirectory}\\${fileName}`;
+
+    const indexingErrors: IndexingError[] = [
+      {
+        id: "1",
+        sourcePath: `Billing data/${fileName}`,
+        destinationFullPath,
+      },
+    ];
+
+    const result = getMappedResolvePathFiles(indexingErrors, "Area Shares/");
+    const normalizedFullPath = destinationFullPath.replace(/\\/g, "/");
+    const expectedFinalPath = `${normalizedFullPath.slice(0, normalizedFullPath.lastIndexOf("/") + 1)}`;
+
+    expect(result).toEqual([
+      {
+        id: "1",
+        relativeSourcePath: "Billing data",
+        sourceName: fileName,
+        relativeFinalPath: expectedFinalPath,
+      },
+    ]);
+
+    const fullPathLength = `${result[0].relativeFinalPath}${result[0].sourceName}`
+      .length;
+    expect(fullPathLength).toBeGreaterThan(260);
+    expect(fullPathLength).toBe(normalizedFullPath.length);
+  });
 });

--- a/ui-spa/src/common/utils/getMappedResolvePathFiles.test.ts
+++ b/ui-spa/src/common/utils/getMappedResolvePathFiles.test.ts
@@ -8,18 +8,22 @@ describe("getMappedResolvePathFiles", () => {
       {
         id: "1",
         sourcePath: "folder1/file1.pdf",
+        destinationFullPath: "destination/folder1/file1.pdf",
       },
       {
         id: "2",
         sourcePath: "folder1/file2.pdf",
+        destinationFullPath: "destination/folder1/file2.pdf",
       },
       {
         id: "3",
         sourcePath: "folder1/folder2/file3.pdf",
+        destinationFullPath: "destination/folder1/folder2/file3.pdf",
       },
       {
         id: "4",
         sourcePath: "file4.pdf",
+        destinationFullPath: "destination/file4.pdf",
       },
     ];
 
@@ -50,11 +54,11 @@ describe("getMappedResolvePathFiles", () => {
       },
     ];
 
-    const result = getMappedResolvePathFiles(indexingErrors, "destination/");
+    const result = getMappedResolvePathFiles(indexingErrors);
     expect(result).toEqual(expectedResult);
   });
 
-  it("Should prefer destinationFullPath for display path length", () => {
+  it("Should use destinationFullPath for display path length", () => {
     const longDirectory =
       "\\\\cps-fileshare\\netapp01\\Area Shares\\CCU Manchester\\Op Milton\\1. Incoming Master Copy\\17. Egress 160726\\Billing data for all suspects\\Billing data\\" +
       "a".repeat(100);
@@ -69,7 +73,7 @@ describe("getMappedResolvePathFiles", () => {
       },
     ];
 
-    const result = getMappedResolvePathFiles(indexingErrors, "Area Shares/");
+    const result = getMappedResolvePathFiles(indexingErrors);
     const normalizedFullPath = destinationFullPath.replace(/\\/g, "/");
     const expectedFinalPath = `${normalizedFullPath.slice(0, normalizedFullPath.lastIndexOf("/") + 1)}`;
 

--- a/ui-spa/src/common/utils/getMappedResolvePathFiles.ts
+++ b/ui-spa/src/common/utils/getMappedResolvePathFiles.ts
@@ -3,17 +3,51 @@ import { getRelativePathFromPath } from "./getRelativePathFromPath";
 import { getFileNameFromPath } from "./getFileNameFromPath";
 import { ResolvePathFileType } from "./getGroupedResolvePaths";
 
+const normalizePathSeparators = (path: string) => path.replace(/\\/g, "/");
+
+const mapFromDestinationFullPath = (
+  error: IndexingError,
+  destinationFullPath: string,
+): ResolvePathFileType => {
+  const normalizedFullPath = normalizePathSeparators(destinationFullPath);
+  const sourceName = getFileNameFromPath(normalizedFullPath);
+  const relativeDir = getRelativePathFromPath(normalizedFullPath);
+
+  return {
+    id: error.id,
+    relativeSourcePath: getRelativePathFromPath(
+      normalizePathSeparators(error.sourcePath),
+    ),
+    sourceName,
+    relativeFinalPath: relativeDir ? `${relativeDir}/` : "",
+  };
+};
+
+const mapFromDestinationAndSourcePath = (
+  error: IndexingError,
+  destinationPath: string,
+): ResolvePathFileType => {
+  const normalizedSourcePath = normalizePathSeparators(error.sourcePath);
+  const relativeSourcePath = getRelativePathFromPath(normalizedSourcePath);
+
+  return {
+    id: error.id,
+    relativeSourcePath,
+    sourceName: getFileNameFromPath(normalizedSourcePath),
+    relativeFinalPath: relativeSourcePath
+      ? `${destinationPath}${relativeSourcePath}/`
+      : destinationPath,
+  };
+};
+
 export const getMappedResolvePathFiles = (
   errors: IndexingError[],
   destinationPath: string,
 ) => {
-  const mappedFiles: ResolvePathFileType[] = errors.map((error) => ({
-    id: error.id,
-    relativeSourcePath: getRelativePathFromPath(error.sourcePath),
-    sourceName: getFileNameFromPath(error.sourcePath),
-    relativeFinalPath: getRelativePathFromPath(error.sourcePath)
-      ? `${destinationPath}${getRelativePathFromPath(error.sourcePath)}/`
-      : destinationPath,
-  }));
+  const mappedFiles: ResolvePathFileType[] = errors.map((error) =>
+    error.destinationFullPath
+      ? mapFromDestinationFullPath(error, error.destinationFullPath)
+      : mapFromDestinationAndSourcePath(error, destinationPath),
+  );
   return mappedFiles;
 };

--- a/ui-spa/src/common/utils/getMappedResolvePathFiles.ts
+++ b/ui-spa/src/common/utils/getMappedResolvePathFiles.ts
@@ -5,49 +5,22 @@ import { ResolvePathFileType } from "./getGroupedResolvePaths";
 
 const normalizePathSeparators = (path: string) => path.replace(/\\/g, "/");
 
-const mapFromDestinationFullPath = (
-  error: IndexingError,
-  destinationFullPath: string,
-): ResolvePathFileType => {
-  const normalizedFullPath = normalizePathSeparators(destinationFullPath);
-  const sourceName = getFileNameFromPath(normalizedFullPath);
-  const relativeDir = getRelativePathFromPath(normalizedFullPath);
+export const getMappedResolvePathFiles = (errors: IndexingError[]) => {
+  const mappedFiles: ResolvePathFileType[] = errors.map((error) => {
+    const normalizedFullPath = normalizePathSeparators(
+      error.destinationFullPath,
+    );
+    const sourceName = getFileNameFromPath(normalizedFullPath);
+    const relativeDir = getRelativePathFromPath(normalizedFullPath);
 
-  return {
-    id: error.id,
-    relativeSourcePath: getRelativePathFromPath(
-      normalizePathSeparators(error.sourcePath),
-    ),
-    sourceName,
-    relativeFinalPath: relativeDir ? `${relativeDir}/` : "",
-  };
-};
-
-const mapFromDestinationAndSourcePath = (
-  error: IndexingError,
-  destinationPath: string,
-): ResolvePathFileType => {
-  const normalizedSourcePath = normalizePathSeparators(error.sourcePath);
-  const relativeSourcePath = getRelativePathFromPath(normalizedSourcePath);
-
-  return {
-    id: error.id,
-    relativeSourcePath,
-    sourceName: getFileNameFromPath(normalizedSourcePath),
-    relativeFinalPath: relativeSourcePath
-      ? `${destinationPath}${relativeSourcePath}/`
-      : destinationPath,
-  };
-};
-
-export const getMappedResolvePathFiles = (
-  errors: IndexingError[],
-  destinationPath: string,
-) => {
-  const mappedFiles: ResolvePathFileType[] = errors.map((error) =>
-    error.destinationFullPath
-      ? mapFromDestinationFullPath(error, error.destinationFullPath)
-      : mapFromDestinationAndSourcePath(error, destinationPath),
-  );
+    return {
+      id: error.id,
+      relativeSourcePath: getRelativePathFromPath(
+        normalizePathSeparators(error.sourcePath),
+      ),
+      sourceName,
+      relativeFinalPath: relativeDir ? `${relativeDir}/` : "",
+    };
+  });
   return mappedFiles;
 };

--- a/ui-spa/src/components/case-management/transfer-materials/RenameTransferFilePage.tsx
+++ b/ui-spa/src/components/case-management/transfer-materials/RenameTransferFilePage.tsx
@@ -25,10 +25,11 @@ export const RenameTransferFilePage: React.FC<RenameTransferFilePageProps> = ({
     setInputValue(val);
   };
 
+  const characterCount = `${relativeFilePath}${inputValue}`.length;
+  const exceedsLimit = characterCount > MAX_FILE_PATH_CHARACTERS;
+
   const getCharactersText = useCallback(() => {
-    const characterCount = `${relativeFilePath}${inputValue}`.length;
-    const tagColor =
-      characterCount > MAX_FILE_PATH_CHARACTERS ? "red" : "green";
+    const tagColor = exceedsLimit ? "red" : "green";
 
     return (
       <>
@@ -47,7 +48,7 @@ export const RenameTransferFilePage: React.FC<RenameTransferFilePageProps> = ({
         </p>
       </>
     );
-  }, [relativeFilePath, inputValue]);
+  }, [characterCount, exceedsLimit]);
   return (
     <div>
       <BackLink to={backLinkUrl} replace state={{ isRouteValid: true }}>
@@ -65,10 +66,12 @@ export const RenameTransferFilePage: React.FC<RenameTransferFilePageProps> = ({
             className={styles.fileNameInput}
           />
           {getCharactersText()}
-          <p>
-            You must reduce this to {MAX_FILE_PATH_CHARACTERS} characters or
-            fewer.
-          </p>
+          {exceedsLimit && (
+            <p>
+              You must reduce this to {MAX_FILE_PATH_CHARACTERS} characters or
+              fewer.
+            </p>
+          )}
           <div className={styles.btnWrapper}>
             <Button onClick={() => handleContinue(inputValue)}>Continue</Button>
             <LinkButton onClick={handleCancel}>Cancel</LinkButton>

--- a/ui-spa/src/components/case-management/transfer-materials/TransferResolveFilePathPage.tsx
+++ b/ui-spa/src/components/case-management/transfer-materials/TransferResolveFilePathPage.tsx
@@ -52,7 +52,7 @@ const TransferResolveFilePathPage = () => {
   );
 
   // Count unresolved files from the backend-flagged list using the same full
-  // path string shown in tags/Rename (destinationFullPath when provided).
+  // path string shown in tags/Rename (from destinationFullPath).
   const largePathFilesCount = useMemo(() => {
     return resolvePathFiles.filter(
       (file) => getFullTransferPath(file).length > MAX_FILE_PATH_CHARACTERS,
@@ -68,10 +68,9 @@ const TransferResolveFilePathPage = () => {
   }, []);
 
   useEffect(() => {
-    if (location?.state?.validationErrors && location?.state?.destinationPath) {
+    if (location?.state?.validationErrors) {
       const initialValue = getMappedResolvePathFiles(
         location?.state?.validationErrors ?? [],
-        location?.state?.destinationPath,
       );
       setResolvePathFiles(initialValue);
       if (!locationState) {

--- a/ui-spa/src/components/case-management/transfer-materials/TransferResolveFilePathPage.tsx
+++ b/ui-spa/src/components/case-management/transfer-materials/TransferResolveFilePathPage.tsx
@@ -45,14 +45,21 @@ const TransferResolveFilePathPage = () => {
       return getGroupedResolvePaths(resolvePathFiles);
     }, [resolvePathFiles]);
 
+  const getFullTransferPath = useCallback(
+    (file: ResolvePathFileType) =>
+      `${file.relativeFinalPath}${file.sourceName}`,
+    [],
+  );
+
+  // Count unresolved files from the backend-flagged list using the same full
+  // path string shown in tags/Rename (destinationFullPath when provided).
   const largePathFilesCount = useMemo(() => {
-    const longPathFiles = resolvePathFiles.filter(
-      (file) =>
-        `${file.relativeFinalPath}${file.sourceName}`.length >
-        MAX_FILE_PATH_CHARACTERS,
-    );
-    return longPathFiles.length;
-  }, [resolvePathFiles]);
+    return resolvePathFiles.filter(
+      (file) => getFullTransferPath(file).length > MAX_FILE_PATH_CHARACTERS,
+    ).length;
+  }, [resolvePathFiles, getFullTransferPath]);
+
+  const hasUnresolvedPathErrors = largePathFilesCount > 0;
 
   useEffect(() => {
     setAriaLiveText(
@@ -74,19 +81,22 @@ const TransferResolveFilePathPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const getCharactersTag = useCallback((filePath: string) => {
-    if (filePath.length > MAX_FILE_PATH_CHARACTERS)
+  const getCharactersTag = useCallback(
+    (filePath: string) => {
+      if (filePath.length > MAX_FILE_PATH_CHARACTERS)
+        return (
+          <Tag gdsTagColour="red" className={styles.statusTag}>
+            {filePath.length} characters
+          </Tag>
+        );
       return (
-        <Tag gdsTagColour="red" className={styles.statusTag}>
+        <Tag gdsTagColour="green" className={styles.statusTag}>
           {filePath.length} characters
         </Tag>
       );
-    return (
-      <Tag gdsTagColour="green" className={styles.statusTag}>
-        {filePath.length} characters
-      </Tag>
-    );
-  }, []);
+    },
+    [],
+  );
 
   const handleRenameButtonClick = (id: string) => {
     const selectedFile = resolvePathFiles.find((file) => file.id === id);
@@ -184,13 +194,13 @@ const TransferResolveFilePathPage = () => {
       <BackLink to={`/case/${caseId}/case-management`} replace>
         Back
       </BackLink>
-      {largePathFilesCount > 0 && (
+      {hasUnresolvedPathErrors && (
         <span role="alert" aria-live="polite" className="govuk-visually-hidden">
           {ariaLiveText}
         </span>
       )}
       <PageContentWrapper>
-        {!largePathFilesCount && resolvePathFiles.length > 0 && (
+        {!hasUnresolvedPathErrors && resolvePathFiles.length > 0 && (
           <div className={styles.successBanner}>
             <NotificationBanner
               type="success"
@@ -204,38 +214,42 @@ const TransferResolveFilePathPage = () => {
           </div>
         )}
         <div className={styles.contentWrapper}>
-          <h1 className="govuk-heading-xl">
-            File paths are too long to transfer
-          </h1>
-          <InsetText data-testid="resolve-file-path-inset-text">
-            {largePathFilesCount === 1 ? (
-              <p>
-                <b>1 file</b> file exceed the 260 character limit.
-              </p>
-            ) : (
-              <p>
-                <b>{largePathFilesCount} files</b> exceed the 260 character
-                limit.
-              </p>
-            )}
+          {hasUnresolvedPathErrors && (
+            <>
+              <h1 className="govuk-heading-xl">
+                File paths are too long to transfer
+              </h1>
+              <InsetText data-testid="resolve-file-path-inset-text">
+                {largePathFilesCount === 1 ? (
+                  <p>
+                    <b>1 file</b> exceeds the 260 character limit.
+                  </p>
+                ) : (
+                  <p>
+                    <b>{largePathFilesCount} files</b> exceed the 260 character
+                    limit.
+                  </p>
+                )}
 
-            <div>
-              <p>The full file path includes:</p>
-              <ul>
-                <li>the destination folder</li>
-                <li> the existing folder structure</li>
-                <li> the file name</li>
-              </ul>
-            </div>
+                <div>
+                  <p>The full file path includes:</p>
+                  <ul>
+                    <li>the destination folder</li>
+                    <li> the existing folder structure</li>
+                    <li> the file name</li>
+                  </ul>
+                </div>
 
-            <div>
-              <p>To continue, you can:</p>
-              <ul>
-                <li>shorten the file names</li>
-                <li>move the files to a folder with a shorter path</li>
-              </ul>
-            </div>
-          </InsetText>
+                <div>
+                  <p>To continue, you can:</p>
+                  <ul>
+                    <li>shorten the file names</li>
+                    <li>move the files to a folder with a shorter path</li>
+                  </ul>
+                </div>
+              </InsetText>
+            </>
+          )}
 
           <div>
             <div>
@@ -265,9 +279,7 @@ const TransferResolveFilePathPage = () => {
                               </span>
                             </div>
                             <div data-testid="character-tag">
-                              {getCharactersTag(
-                                `${file.relativeFinalPath}${file.sourceName}`,
-                              )}
+                              {getCharactersTag(getFullTransferPath(file))}
                             </div>
                             <div className={styles.renameButton}>
                               <Button
@@ -291,7 +303,7 @@ const TransferResolveFilePathPage = () => {
             {resolvePathFiles.length > 0 && (
               <div className={styles.btnWrapper}>
                 <Button
-                  disabled={disableBtns || largePathFilesCount > 0}
+                  disabled={disableBtns || hasUnresolvedPathErrors}
                   onClick={handleStartTransferBtnClick}
                 >
                   Start transfer

--- a/ui-spa/src/mocks/data/validateTransfer.dev.ts
+++ b/ui-spa/src/mocks/data/validateTransfer.dev.ts
@@ -58,16 +58,22 @@ export const egressToNetAppIndexingErrorDev: IndexingFileTransferResponse = {
       id: "id_3",
       sourcePath:
         "egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswweee.pdf",
+      destinationFullPath:
+        "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder3/file3qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswweee.pdf",
     },
     {
       id: "id_4",
       sourcePath:
         "egress/folder3/file4qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
+      destinationFullPath:
+        "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder3/file4qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssssssswwee.pdf",
     },
     {
       id: "id_5",
       sourcePath:
         "egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
+      destinationFullPath:
+        "egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/folder1/egress/destination/egress/folder4/folder5/file5qeeweweweweewwwweeewwwwwwwwwwwwwwwwwwwwwwwssweesss.pdf",
     },
   ],
   files: [

--- a/ui-spa/src/schemas/responses/indexingFileTransferResponse.ts
+++ b/ui-spa/src/schemas/responses/indexingFileTransferResponse.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const indexingErrorSchema = z.object({
   id: z.string(),
   sourcePath: z.string(),
-  destinationFullPath: z.string().optional(),
+  destinationFullPath: z.string(),
 });
 
 export const indexingFileTransferResponseSchema = z.object({

--- a/ui-spa/src/schemas/responses/indexingFileTransferResponse.ts
+++ b/ui-spa/src/schemas/responses/indexingFileTransferResponse.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const indexingErrorSchema = z.object({
   id: z.string(),
   sourcePath: z.string(),
+  destinationFullPath: z.string().optional(),
 });
 
 export const indexingFileTransferResponseSchema = z.object({


### PR DESCRIPTION
# PR checklist

Tick what applies before you raise. Delete anything that doesn't.

## Correctness
- [x] Does what the ticket asks for
- [x] Handles the edge cases (empty, null, zero, large inputs), not just the happy path
- [x] Errors are handled, not swallowed
- [x] New logic has tests, including the failure cases
- [x] Tests assert something real, not just run the code

## Keeping it simple
- [x] Doesn't rebuild something that already exists in the codebase
- [x] No more complex or slower than it needs to be
- [x] No leftover debug logging or commented-out code

## Easy to miss (a green pipeline won't flag these)
- [x] One logical change, not a pile of unrelated stuff

### If you touched the backend
- [x] Schema changes have a migration, and the Down() doesn't drop anything it shouldn't
- [x] New app settings are wired into the fa-config templates
- [x] Secrets use Key Vault references, not plain text
- [x] New outbound HTTP clients go through the shared resilience handler (AddResiliencePolicyHandler), rather than hand-rolling retries
- [x] New calls to an external service (DDEI, Egress, NetApp) have client tests against a WireMock stub (for the serialisation, auth and error handling) and are covered by the integration tests that run against the real dev services
- [x] Ran dotnet format, since CI builds and tests but doesn't check formatting

### If you touched the UI
- [ ] Ran the e2e/ suite locally (the PR build only runs the mocked tests; the full suite runs post-merge and gates the deploy)
- [x] API changes are reflected in the MSW handlers in src/mocks and the matching zod schema, so the mocked tests aren't passing against a contract that's gone
- [x] New config or feature flags are wired into the VITE build variables, not just added in code
- [x] Data fetches handle the loading, empty and error states, not just success, and match how the rest of the app already does it
- [x] Ran prettier (npm run prettier:format), since CI lints but doesn't check formatting
- [x] Checked accessibility (keyboard nav, screen reader, sensible labels), since the Lighthouse run is manual and won't flag it for you