### PR TITLE
0 byte transfers no longer show as fail cases

### DIFF
--- a/backend/CPS.ComplexCases.ActivityLog/Models/FileTransferDetails.cs
+++ b/backend/CPS.ComplexCases.ActivityLog/Models/FileTransferDetails.cs
@@ -13,7 +13,8 @@ public class FileTransferDetails
     public int TotalFiles { get; set; }
     public int TransferedFileCount => Files.Count;
     public int ErrorFileCount => Errors.Count;
-    public bool IsCompleted => TransferedFileCount == TotalFiles && ErrorFileCount == 0;
+    public int SkippedFileCount => Skipped.Count;
+    public bool IsCompleted => TransferedFileCount + SkippedFileCount == TotalFiles && ErrorFileCount == 0;
     public bool SourceFilesDeletedSuccessfully => TransferType == nameof(DomainEnums.TransferType.Move) &&
                                                   TransferDirection == nameof(DomainEnums.TransferDirection.EgressToNetApp) &&
                                                   DeletionErrors.Count == 0;
@@ -21,6 +22,7 @@ public class FileTransferDetails
     public long TotalBytesTransferred => GetTotalBytesTransferred();
     public required List<FileTransferItem> Files { get; set; } = [];
     public required List<FileTransferError> Errors { get; set; } = [];
+    public List<FileTransferError> Skipped { get; set; } = [];
     public List<FileTransferError> DeletionErrors { get; set; } = [];
     public string? ExceptionMessage { get; set; }
     public DateTime? StartTime { get; set; }

--- a/backend/CPS.ComplexCases.FileTransfer.API.Tests/Unit/Durable/Activity/TransferFileTests.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API.Tests/Unit/Durable/Activity/TransferFileTests.cs
@@ -883,10 +883,11 @@ public class TransferFileTests
     }
 
     [Fact]
-    public async Task Run_ZeroLengthSource_ReturnsGeneralErrorAndDoesNotUpload()
+    public async Task Run_ZeroLengthSource_NetAppToEgress_SkipsWithoutUploading()
     {
-        // Arrange — a 0-byte / unknown-length source should fail fast with a classified error.
+        // Arrange — Egress cannot materialise a 0-byte object; skip instead of false success.
         var payload = CreatePayload();
+        payload.TransferDirection = TransferDirection.NetAppToEgress;
         var stream = new MemoryStream(Array.Empty<byte>());
 
         _storageClientFactoryMock
@@ -905,6 +906,56 @@ public class TransferFileTests
         var result = await _activity.Run(payload);
 
         // Assert
+        Assert.True(result.IsSkipped);
+        Assert.False(result.IsSuccess);
+        Assert.NotNull(result.SkippedItem);
+        Assert.Equal(0L, result.SkippedItem.Size);
+        Assert.Equal(TransferItemStatus.Skipped, result.SkippedItem.Status);
+
+        _destinationClientMock.Verify(x => x.InitiateUploadAsync(
+                It.IsAny<string>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()),
+            Times.Never);
+
+        _destinationClientMock.Verify(x => x.UploadChunkAsync(
+                It.IsAny<UploadSession>(), It.IsAny<int>(), It.IsAny<byte[]>(),
+                It.IsAny<long?>(), It.IsAny<long?>(), It.IsAny<long?>(),
+                It.IsAny<string?>(), It.IsAny<string?>()),
+            Times.Never);
+
+        _destinationClientMock.Verify(x => x.CompleteUploadAsync(
+                It.IsAny<UploadSession>(),
+                It.IsAny<string?>(),
+                It.IsAny<Dictionary<int, string>?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Run_UnknownLengthSource_ReturnsGeneralErrorAndDoesNotUpload()
+    {
+        // Arrange — an unreadable length (totalSize < 0) should still fail fast.
+        var payload = CreatePayload();
+        var stream = new MemoryStream(Array.Empty<byte>());
+
+        _storageClientFactoryMock
+            .Setup(x => x.GetClientsForDirection(payload.TransferDirection))
+            .Returns((_sourceClientMock.Object, _destinationClientMock.Object));
+
+        _sourceClientMock
+            .Setup(x => x.OpenReadStreamAsync(payload.SourcePath.Path,
+                payload.WorkspaceId,
+                payload.SourcePath.FileId,
+                payload.BearerToken,
+                payload.BucketName))
+            .ReturnsAsync((stream, -1L));
+
+        // Act
+        var result = await _activity.Run(payload);
+
+        // Assert
         Assert.False(result.IsSuccess);
         Assert.NotNull(result.FailedItem);
         Assert.Equal(TransferErrorCode.GeneralError, result.FailedItem.ErrorCode);
@@ -913,6 +964,72 @@ public class TransferFileTests
                 It.IsAny<string>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<string?>(),
                 It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task Run_ZeroLengthSource_NetAppDestination_UsesSinglePut()
+    {
+        // Arrange — 0 KB transfers to NetApp must still succeed via the single PUT path.
+        var payload = CreatePayload(); // EgressToNetApp → NetApp destination
+        var stream = new MemoryStream(Array.Empty<byte>());
+
+        var netAppArgFactoryMock = new Mock<INetAppArgFactory>();
+        netAppArgFactoryMock
+            .Setup(f => f.CreateUploadObjectArg(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<Stream>(),
+                It.IsAny<long>(),
+                It.IsAny<bool>()))
+            .Returns((string bearerToken, string bucketName, string objectName, Stream fileStream, long length,
+                bool disablePayloadSigning) => new UploadObjectArg
+                {
+                    BearerToken = bearerToken,
+                    BucketName = bucketName,
+                    ObjectKey = objectName,
+                    Stream = fileStream,
+                    ContentLength = length,
+                    DisablePayloadSigning = disablePayloadSigning
+                });
+
+        var netAppClientMock = new Mock<INetAppClient>();
+        // FileExistsAsync → DoesObjectExistAsync defaults to false under Moq (loose).
+        netAppClientMock
+            .Setup(c => c.UploadObjectAsync(It.IsAny<UploadObjectArg>()))
+            .ReturnsAsync(true);
+
+        var netAppDestinationClient = new NetAppStorageClient(
+            netAppClientMock.Object,
+            netAppArgFactoryMock.Object,
+            Mock.Of<ICaseMetadataService>(),
+            Mock.Of<INetAppS3HttpClient>(),
+            Mock.Of<INetAppS3HttpArgFactory>(),
+            Mock.Of<ILogger<NetAppStorageClient>>());
+
+        _storageClientFactoryMock
+            .Setup(x => x.GetClientsForDirection(payload.TransferDirection))
+            .Returns((_sourceClientMock.Object, netAppDestinationClient));
+
+        _sourceClientMock
+            .Setup(x => x.OpenReadStreamAsync(payload.SourcePath.Path,
+                payload.WorkspaceId,
+                payload.SourcePath.FileId,
+                payload.BearerToken,
+                payload.BucketName))
+            .ReturnsAsync((stream, 0L));
+
+        // Act
+        var result = await _activity.Run(payload);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.SuccessfulItem);
+        Assert.Equal(0L, result.SuccessfulItem.Size);
+
+        netAppClientMock.Verify(
+            c => c.UploadObjectAsync(It.Is<UploadObjectArg>(a => a.ContentLength == 0)),
+            Times.Once);
     }
 
     [Fact]

--- a/backend/CPS.ComplexCases.FileTransfer.API.Tests/Unit/Durable/State/TransferEntityStateTests.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API.Tests/Unit/Durable/State/TransferEntityStateTests.cs
@@ -81,6 +81,61 @@ public class TransferEntityStateTests
     }
 
     [Fact]
+    public void AddSkippedItem_UpdatesStateCorrectly()
+    {
+        // Arrange
+        var state = new TransferEntityState();
+        state.Initialize(new TransferEntity { DestinationPath = "dest", BearerToken = "fakeBearerToken" });
+
+        var item = new TransferItem
+        {
+            SourcePath = "empty.txt",
+            Size = 0,
+            Status = TransferItemStatus.Skipped,
+            IsRenamed = false
+        };
+
+        // Act
+        state.AddSkippedItem(item);
+
+        // Assert
+        Assert.Single(state.CurrentState.SkippedItems);
+        Assert.Equal(1, state.CurrentState.SkippedFiles);
+        Assert.Equal(1, state.CurrentState.ProcessedFiles);
+        Assert.Equal(0, state.CurrentState.FailedFiles);
+        Assert.Contains(item, state.CurrentState.SkippedItems);
+    }
+
+    [Fact]
+    public void FinalizeTransfer_WithOnlySkippedItems_SetsStatusToCompleted()
+    {
+        // Arrange
+        var state = new TransferEntityState();
+        state.Initialize(new TransferEntity
+        {
+            DestinationPath = "dest",
+            BearerToken = "fakeBearerToken",
+            SkippedItems =
+            [
+                new TransferItem
+                {
+                    SourcePath = "empty.txt",
+                    Status = TransferItemStatus.Skipped,
+                    IsRenamed = false,
+                    Size = 0
+                }
+            ],
+            FailedItems = []
+        });
+
+        // Act
+        state.FinalizeTransfer();
+
+        // Assert — skips alone must not mark the batch failed / partially completed.
+        Assert.Equal(TransferStatus.Completed, state.CurrentState.Status);
+    }
+
+    [Fact]
     public void FinalizeTransfer_WithOnlySuccessfulItems_SetsStatusToCompleted()
     {
         // Arrange

--- a/backend/CPS.ComplexCases.FileTransfer.API/Dtos/TransferStatusDto.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Dtos/TransferStatusDto.cs
@@ -16,11 +16,13 @@ public class TransferStatusDto
     public DateTime? CompletedAt { get; init; }
     public List<TransferFailedItemDto> FailedItems { get; init; } = [];
     public List<TransferSuccessfulItemDto> SuccessfulItems { get; init; } = [];
+    public List<TransferSkippedItemDto> SkippedItems { get; init; } = [];
     public string? UserName { get; init; }
     public int TotalFiles { get; init; }
     public int ProcessedFiles { get; init; }
     public int SuccessfulFiles { get; init; }
     public int FailedFiles { get; init; }
+    public int SkippedFiles { get; init; }
 
     public static TransferStatusDto From(TransferEntity entity) => new()
     {
@@ -37,11 +39,16 @@ public class TransferStatusDto
                 or TransferStatus.PartiallyCompleted or TransferStatus.Failed
             ? entity.SuccessfulItems.Select(TransferSuccessfulItemDto.From).ToList()
             : [],
+        SkippedItems = entity.Status is TransferStatus.Completed
+                or TransferStatus.PartiallyCompleted or TransferStatus.Failed
+            ? entity.SkippedItems.Select(TransferSkippedItemDto.From).ToList()
+            : [],
         UserName = entity.UserName,
         TotalFiles = entity.TotalFiles,
         ProcessedFiles = entity.ProcessedFiles,
         SuccessfulFiles = entity.SuccessfulFiles,
         FailedFiles = entity.FailedFiles,
+        SkippedFiles = entity.SkippedFiles,
     };
 }
 
@@ -63,6 +70,19 @@ public class TransferSuccessfulItemDto
     public long Size { get; init; }
 
     public static TransferSuccessfulItemDto From(TransferItem item) => new()
+    {
+        SourcePath = item.SourcePath,
+        Size = item.Size,
+    };
+}
+
+public class TransferSkippedItemDto
+{
+    public required string SourcePath { get; init; }
+    public long Size { get; init; }
+    public string Reason { get; init; } = "Empty (0-byte) files cannot be uploaded to Egress.";
+
+    public static TransferSkippedItemDto From(TransferItem item) => new()
     {
         SourcePath = item.SourcePath,
         Size = item.Size,

--- a/backend/CPS.ComplexCases.FileTransfer.API/Durable/Activity/TransferFile.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Durable/Activity/TransferFile.cs
@@ -97,21 +97,17 @@ public class TransferFile(
 
             using (sourceStream)
             {
-                if (totalSize <= 0)
+                // Unknown length cannot drive a sized multipart upload.
+                if (totalSize < 0)
                 {
-                    // A 0-byte or unknown-length source cannot be transferred as a sized multipart
-                    // upload and has produced fast 0-byte failures in production. 
-                    // Fail fast with a clear, classified error and record the size so this
-                    // mode is distinguishable in telemetry from chunk-500 / create-upload-404 failures.
-                    // Deliberate: genuinely empty 0-byte files are out of scope and are rejected here too.
                     _logger.LogWarning(
-                        "Source returned a non-positive content length ({Size}) for {Path}; failing fast.",
+                        "Source returned an unreadable content length ({Size}) for {Path}; failing fast.",
                         totalSize, payload.SourcePath.Path);
 
                     telemetryEvent.FileSizeInBytes = totalSize;
                     telemetryEvent.ErrorCode = TransferErrorCode.GeneralError.ToString();
                     telemetryEvent.ErrorMessage =
-                        $"Source content length was {totalSize} (zero or unknown); the file could not be transferred.";
+                        $"Source content length was {totalSize} (unknown); the file could not be transferred.";
 
                     return CreateFailureResult(
                         payload.SourcePath.FullFilePath ?? payload.SourcePath.Path,
@@ -122,9 +118,27 @@ public class TransferFile(
                 bool needsMd5 = destinationClient is EgressStorageClient;
                 bool isNetApp = destinationClient is NetAppStorageClient;
 
+                // Egress has no single-PUT path and cannot materialise a 0-byte object via multipart
+                // (create-upload + complete with no parts returns OK but leaves no file). Skip so the
+                // batch is not failed and the item is reported rather than falsely marked transferred.
+                if (totalSize == 0 && payload.TransferDirection == TransferDirection.NetAppToEgress)
+                {
+                    _logger.LogInformation(
+                        "Skipping empty (0-byte) file for NetApp→Egress transfer: {Path}",
+                        payload.SourcePath.Path);
+
+                    telemetryEvent.FileSizeInBytes = 0;
+                    telemetryEvent.IsSuccessful = true;
+                    telemetryEvent.ErrorCode = "EmptyFileSkipped";
+                    telemetryEvent.ErrorMessage =
+                        "Empty (0-byte) files cannot be uploaded to Egress and were skipped.";
+
+                    return CreateSkippedResult(payload, totalSize, startTime);
+                }
+
                 TransferResult result;
 
-                // Small NetApp files use single PUT
+                // Small NetApp files (including 0-byte) use single PUT
                 if (isNetApp && totalSize <= _sizeConfig.MinMultipartSizeBytes)
                 {
                     result = await HandleSingleUpload(
@@ -150,12 +164,13 @@ public class TransferFile(
                 }
 
                 telemetryEvent.FileSizeInBytes = totalSize;
-                telemetryEvent.TransferEndTime = result.SuccessfulItem?.EndTime ?? DateTime.UtcNow;
-                telemetryEvent.IsSuccessful = result.IsSuccess;
+                telemetryEvent.TransferEndTime =
+                    result.SuccessfulItem?.EndTime ?? result.SkippedItem?.EndTime ?? DateTime.UtcNow;
+                telemetryEvent.IsSuccessful = result.IsSuccess || result.IsSkipped;
                 telemetryEvent.IsMultipart = result.IsSuccess && result.SuccessfulItem!.TotalPartsCount > 1;
                 telemetryEvent.TotalPartsCount = result.IsSuccess ? result.SuccessfulItem!.TotalPartsCount : 0;
 
-                if (!result.IsSuccess && result.FailedItem != null)
+                if (!result.IsSuccess && !result.IsSkipped && result.FailedItem != null)
                 {
                     telemetryEvent.ErrorCode = result.FailedItem.ErrorCode.ToString();
                     telemetryEvent.ErrorMessage = result.FailedItem.ErrorMessage;
@@ -504,6 +519,25 @@ public class TransferFile(
         };
 
         return new TransferResult { IsSuccess = true, SuccessfulItem = item };
+    }
+
+    private static TransferResult CreateSkippedResult(TransferFilePayload payload, long totalSize, DateTime startTime)
+    {
+        var endTime = DateTime.UtcNow;
+
+        var item = new TransferItem
+        {
+            SourcePath = payload.SourcePath.FullFilePath ?? payload.SourcePath.Path,
+            Status = TransferItemStatus.Skipped,
+            Size = totalSize,
+            IsRenamed = payload.SourcePath.ModifiedPath != null,
+            FileId = payload.SourcePath.FileId,
+            StartTime = startTime,
+            EndTime = endTime,
+            TotalPartsCount = 0
+        };
+
+        return new TransferResult { IsSkipped = true, SkippedItem = item };
     }
 
     private TransferResult CreateFailureResult(

--- a/backend/CPS.ComplexCases.FileTransfer.API/Durable/Activity/UpdateActivityLog.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Durable/Activity/UpdateActivityLog.cs
@@ -80,6 +80,13 @@ public class UpdateActivityLog(IActivityLogService activityLogService, ILogger<U
             ErrorMessage = x.ErrorMessage
         }).ToList();
 
+        var skippedItems = entity.State.SkippedItems.Select(x => new FileTransferError
+        {
+            Path = x.SourcePath,
+            ErrorCode = "EmptyFileSkipped",
+            ErrorMessage = "Empty (0-byte) files cannot be uploaded to Egress and were skipped."
+        }).ToList();
+
         var sourcePath = entity.State.SourceRootFolderPath
             ?? Path.GetDirectoryName(entity.State.SourcePaths[0].FullFilePath)
             ?? entity.State.SourcePaths[0].Path;
@@ -116,6 +123,7 @@ public class UpdateActivityLog(IActivityLogService activityLogService, ILogger<U
             DestinationPath = entity.State.DestinationPath,
             Files = successfulItems,
             Errors = errorItems,
+            Skipped = skippedItems,
             DeletionErrors = deletionErrors,
             ExceptionMessage = payload.ExceptionMessage,
             StartTime = entity.State.StartedAt,

--- a/backend/CPS.ComplexCases.FileTransfer.API/Durable/Helpers/TransferResultProcessor.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Durable/Helpers/TransferResultProcessor.cs
@@ -1,0 +1,51 @@
+using CPS.ComplexCases.FileTransfer.API.Durable.Payloads.Domain;
+using CPS.ComplexCases.FileTransfer.API.Durable.State;
+using CPS.ComplexCases.FileTransfer.API.Telemetry;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Entities;
+
+namespace CPS.ComplexCases.FileTransfer.API.Durable.Helpers;
+
+
+public static class TransferResultProcessor
+{
+    public static async Task ProcessAsync(
+        TaskOrchestrationContext context,
+        EntityInstanceId entityId,
+        TransferResult[] results,
+        TransferOrchestrationEvent telemetryEvent,
+        bool isRetry = false)
+    {
+        foreach (var result in results)
+        {
+            if (result != null && result.IsSkipped && result.SkippedItem != null)
+            {
+                await context.Entities.CallEntityAsync(
+                    entityId,
+                    nameof(TransferEntityState.AddSkippedItem),
+                    result.SkippedItem);
+            }
+            else if (result != null && result.IsSuccess && result.SuccessfulItem != null)
+            {
+                await context.Entities.CallEntityAsync(
+                    entityId,
+                    isRetry ? nameof(TransferEntityState.AddSuccessfulRetryItem)
+                            : nameof(TransferEntityState.AddSuccessfulItem),
+                    result.SuccessfulItem);
+
+                telemetryEvent.TotalFilesTransferred++;
+                telemetryEvent.TotalBytesTransferred += result.SuccessfulItem.Size;
+            }
+            else if (result != null && !result.IsSuccess && result.FailedItem != null)
+            {
+                await context.Entities.CallEntityAsync(
+                    entityId,
+                    isRetry ? nameof(TransferEntityState.AddFailedRetryItem)
+                            : nameof(TransferEntityState.AddFailedItem),
+                    result.FailedItem);
+
+                telemetryEvent.TotalFilesFailed++;
+            }
+        }
+    }
+}

--- a/backend/CPS.ComplexCases.FileTransfer.API/Durable/Helpers/TransferResultProcessor.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Durable/Helpers/TransferResultProcessor.cs
@@ -1,8 +1,10 @@
 using CPS.ComplexCases.FileTransfer.API.Durable.Payloads.Domain;
 using CPS.ComplexCases.FileTransfer.API.Durable.State;
+using CPS.ComplexCases.FileTransfer.API.Models.Domain.Enums;
 using CPS.ComplexCases.FileTransfer.API.Telemetry;
 using Microsoft.DurableTask;
 using Microsoft.DurableTask.Entities;
+using Microsoft.Extensions.Logging;
 
 namespace CPS.ComplexCases.FileTransfer.API.Durable.Helpers;
 
@@ -16,16 +18,23 @@ public static class TransferResultProcessor
         TransferOrchestrationEvent telemetryEvent,
         bool isRetry = false)
     {
+        var logger = context.CreateReplaySafeLogger(nameof(TransferResultProcessor));
+
         foreach (var result in results)
         {
-            if (result != null && result.IsSkipped && result.SkippedItem != null)
+            if (result is null)
+            {
+                continue;
+            }
+
+            if (result.IsSkipped && result.SkippedItem != null)
             {
                 await context.Entities.CallEntityAsync(
                     entityId,
                     nameof(TransferEntityState.AddSkippedItem),
                     result.SkippedItem);
             }
-            else if (result != null && result.IsSuccess && result.SuccessfulItem != null)
+            else if (result.IsSuccess && result.SuccessfulItem != null)
             {
                 await context.Entities.CallEntityAsync(
                     entityId,
@@ -36,13 +45,41 @@ public static class TransferResultProcessor
                 telemetryEvent.TotalFilesTransferred++;
                 telemetryEvent.TotalBytesTransferred += result.SuccessfulItem.Size;
             }
-            else if (result != null && !result.IsSuccess && result.FailedItem != null)
+            else if (!result.IsSuccess && result.FailedItem != null)
             {
                 await context.Entities.CallEntityAsync(
                     entityId,
                     isRetry ? nameof(TransferEntityState.AddFailedRetryItem)
                             : nameof(TransferEntityState.AddFailedItem),
                     result.FailedItem);
+
+                telemetryEvent.TotalFilesFailed++;
+            }
+            else
+            {
+                logger.LogWarning(
+                    "Unclassifiable transfer result. IsSuccess={IsSuccess}, IsSkipped={IsSkipped}, HasSuccessfulItem={HasSuccessfulItem}, HasSkippedItem={HasSkippedItem}, HasFailedItem={HasFailedItem}",
+                    result.IsSuccess,
+                    result.IsSkipped,
+                    result.SuccessfulItem is not null,
+                    result.SkippedItem is not null,
+                    result.FailedItem is not null);
+
+                var failedItem = result.FailedItem ?? new TransferFailedItem
+                {
+                    SourcePath = result.SuccessfulItem?.SourcePath
+                        ?? result.SkippedItem?.SourcePath
+                        ?? "unknown",
+                    Status = TransferItemStatus.Failed,
+                    ErrorCode = TransferErrorCode.GeneralError,
+                    ErrorMessage = "Unclassifiable transfer result"
+                };
+
+                await context.Entities.CallEntityAsync(
+                    entityId,
+                    isRetry ? nameof(TransferEntityState.AddFailedRetryItem)
+                            : nameof(TransferEntityState.AddFailedItem),
+                    failedItem);
 
                 telemetryEvent.TotalFilesFailed++;
             }

--- a/backend/CPS.ComplexCases.FileTransfer.API/Durable/Orchestration/BatchOrchestratorBase.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Durable/Orchestration/BatchOrchestratorBase.cs
@@ -266,7 +266,14 @@ public abstract class BatchOrchestratorBase<TPayload, TFileItem>(
     {
         foreach (var result in results)
         {
-            if (result != null && result.IsSuccess && result.SuccessfulItem != null)
+            if (result != null && result.IsSkipped && result.SkippedItem != null)
+            {
+                await context.Entities.CallEntityAsync(
+                    entityId,
+                    nameof(TransferEntityState.AddSkippedItem),
+                    result.SkippedItem);
+            }
+            else if (result != null && result.IsSuccess && result.SuccessfulItem != null)
             {
                 await context.Entities.CallEntityAsync(
                     entityId,

--- a/backend/CPS.ComplexCases.FileTransfer.API/Durable/Orchestration/BatchOrchestratorBase.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Durable/Orchestration/BatchOrchestratorBase.cs
@@ -3,6 +3,7 @@ using CPS.ComplexCases.Common.Models.Domain.Enums;
 using CPS.ComplexCases.Common.Models.Requests;
 using CPS.ComplexCases.Common.Telemetry;
 using CPS.ComplexCases.FileTransfer.API.Durable.Activity;
+using CPS.ComplexCases.FileTransfer.API.Durable.Helpers;
 using CPS.ComplexCases.FileTransfer.API.Durable.Payloads;
 using CPS.ComplexCases.FileTransfer.API.Durable.Payloads.Domain;
 using CPS.ComplexCases.FileTransfer.API.Durable.State;
@@ -195,7 +196,7 @@ public abstract class BatchOrchestratorBase<TPayload, TFileItem>(
             if (batch.Count >= batchSize)
             {
                 var batchResults = await Task.WhenAll(batch);
-                await ProcessTransferResults(context, entityId, batchResults, telemetryEvent);
+                await TransferResultProcessor.ProcessAsync(context, entityId, batchResults, telemetryEvent);
                 allResults.AddRange(batchResults);
                 batch.Clear();
             }
@@ -204,7 +205,7 @@ public abstract class BatchOrchestratorBase<TPayload, TFileItem>(
         if (batch.Count > 0)
         {
             var remainingResults = await Task.WhenAll(batch);
-            await ProcessTransferResults(context, entityId, remainingResults, telemetryEvent);
+            await TransferResultProcessor.ProcessAsync(context, entityId, remainingResults, telemetryEvent);
             allResults.AddRange(remainingResults);
         }
 
@@ -250,50 +251,10 @@ public abstract class BatchOrchestratorBase<TPayload, TFileItem>(
                 .ToList();
 
             var retryResults = await Task.WhenAll(retryBatch);
-            await ProcessTransferResults(context, entityId, retryResults, telemetryEvent, isRetry: true);
+            await TransferResultProcessor.ProcessAsync(context, entityId, retryResults, telemetryEvent, isRetry: true);
 
             allResults.RemoveAll(r => r != null && !r.IsSuccess && r.FailedItem?.ErrorCode == TransferErrorCode.Transient);
             allResults.AddRange(retryResults);
-        }
-    }
-
-    protected static async Task ProcessTransferResults(
-        TaskOrchestrationContext context,
-        EntityInstanceId entityId,
-        TransferResult[] results,
-        TransferOrchestrationEvent telemetryEvent,
-        bool isRetry = false)
-    {
-        foreach (var result in results)
-        {
-            if (result != null && result.IsSkipped && result.SkippedItem != null)
-            {
-                await context.Entities.CallEntityAsync(
-                    entityId,
-                    nameof(TransferEntityState.AddSkippedItem),
-                    result.SkippedItem);
-            }
-            else if (result != null && result.IsSuccess && result.SuccessfulItem != null)
-            {
-                await context.Entities.CallEntityAsync(
-                    entityId,
-                    isRetry ? nameof(TransferEntityState.AddSuccessfulRetryItem)
-                            : nameof(TransferEntityState.AddSuccessfulItem),
-                    result.SuccessfulItem);
-
-                telemetryEvent.TotalFilesTransferred++;
-                telemetryEvent.TotalBytesTransferred += result.SuccessfulItem.Size;
-            }
-            else if (result != null && !result.IsSuccess && result.FailedItem != null)
-            {
-                await context.Entities.CallEntityAsync(
-                    entityId,
-                    isRetry ? nameof(TransferEntityState.AddFailedRetryItem)
-                            : nameof(TransferEntityState.AddFailedItem),
-                    result.FailedItem);
-
-                telemetryEvent.TotalFilesFailed++;
-            }
         }
     }
 

--- a/backend/CPS.ComplexCases.FileTransfer.API/Durable/Orchestration/TransferOrchestrator.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Durable/Orchestration/TransferOrchestrator.cs
@@ -4,6 +4,7 @@ using CPS.ComplexCases.Common.Models.Requests;
 using CPS.ComplexCases.Common.Telemetry;
 using CPS.ComplexCases.Egress.Client;
 using CPS.ComplexCases.FileTransfer.API.Durable.Activity;
+using CPS.ComplexCases.FileTransfer.API.Durable.Helpers;
 using CPS.ComplexCases.FileTransfer.API.Durable.Payloads;
 using CPS.ComplexCases.FileTransfer.API.Durable.Payloads.Domain;
 using CPS.ComplexCases.FileTransfer.API.Durable.State;
@@ -207,7 +208,7 @@ public class TransferOrchestrator(IOptions<SizeConfig> sizeConfig, ITelemetryCli
                 {
                     // Process batch results and update entity synchronously
                     var batchResults = await Task.WhenAll(batch);
-                    await ProcessTransferResults(context, entityId, batchResults, transferOrchestrationEvent);
+                    await TransferResultProcessor.ProcessAsync(context, entityId, batchResults, transferOrchestrationEvent);
                     allResults.AddRange(batchResults);
                     batch.Clear();
                 }
@@ -217,7 +218,7 @@ public class TransferOrchestrator(IOptions<SizeConfig> sizeConfig, ITelemetryCli
             if (batch.Count > 0)
             {
                 var remainingResults = await Task.WhenAll(batch);
-                await ProcessTransferResults(context, entityId, remainingResults, transferOrchestrationEvent);
+                await TransferResultProcessor.ProcessAsync(context, entityId, remainingResults, transferOrchestrationEvent);
                 allResults.AddRange(remainingResults);
             }
 
@@ -290,7 +291,7 @@ public class TransferOrchestrator(IOptions<SizeConfig> sizeConfig, ITelemetryCli
                             })).ToList();
 
                     var batchResults = await Task.WhenAll(retryBatch);
-                    await ProcessTransferResults(context, entityId, batchResults, transferOrchestrationEvent, isRetry: true);
+                    await TransferResultProcessor.ProcessAsync(context, entityId, batchResults, transferOrchestrationEvent, isRetry: true);
                     retryResults.AddRange(batchResults);
                 }
 
@@ -367,55 +368,6 @@ public class TransferOrchestrator(IOptions<SizeConfig> sizeConfig, ITelemetryCli
         {
             transferOrchestrationEvent.OrchestrationEndTime = context.CurrentUtcDateTime;
             _telemetryClient.TrackEvent(transferOrchestrationEvent);
-        }
-    }
-
-    /// <summary>
-    /// Processes transfer results and updates the entity synchronously
-    /// This eliminates the race condition by ensuring all entity updates are completed
-    /// before the orchestrator continues
-    /// </summary>
-    private static async Task ProcessTransferResults(
-        TaskOrchestrationContext context,
-        EntityInstanceId entityId,
-        TransferResult[] results,
-        TransferOrchestrationEvent telemetryEvent,
-        bool isRetry = false)
-    {
-        foreach (var result in results)
-        {
-            if (result != null && result.IsSkipped && result.SkippedItem != null)
-            {
-                await context.Entities.CallEntityAsync(
-                    entityId,
-                    nameof(TransferEntityState.AddSkippedItem),
-                    result.SkippedItem);
-            }
-            else if (result != null && result.IsSuccess && result.SuccessfulItem != null)
-            {
-                // Use CallEntityAsync for synchronous entity updates
-                await context.Entities.CallEntityAsync(
-                    entityId,
-                    isRetry ? nameof(TransferEntityState.AddSuccessfulRetryItem)
-                            : nameof(TransferEntityState.AddSuccessfulItem),
-                    result.SuccessfulItem);
-
-                // Update telemetry event
-                telemetryEvent.TotalFilesTransferred++;
-                telemetryEvent.TotalBytesTransferred += result.SuccessfulItem.Size;
-            }
-            else if (result != null && !result.IsSuccess && result.FailedItem != null)
-            {
-                // Use CallEntityAsync for synchronous entity updates
-                await context.Entities.CallEntityAsync(
-                    entityId,
-                    isRetry ? nameof(TransferEntityState.AddFailedRetryItem)
-                            : nameof(TransferEntityState.AddFailedItem),
-                    result.FailedItem);
-
-                // Update telemetry event
-                telemetryEvent.TotalFilesFailed++;
-            }
         }
     }
 

--- a/backend/CPS.ComplexCases.FileTransfer.API/Durable/Orchestration/TransferOrchestrator.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Durable/Orchestration/TransferOrchestrator.cs
@@ -384,7 +384,14 @@ public class TransferOrchestrator(IOptions<SizeConfig> sizeConfig, ITelemetryCli
     {
         foreach (var result in results)
         {
-            if (result != null && result.IsSuccess && result.SuccessfulItem != null)
+            if (result != null && result.IsSkipped && result.SkippedItem != null)
+            {
+                await context.Entities.CallEntityAsync(
+                    entityId,
+                    nameof(TransferEntityState.AddSkippedItem),
+                    result.SkippedItem);
+            }
+            else if (result != null && result.IsSuccess && result.SuccessfulItem != null)
             {
                 // Use CallEntityAsync for synchronous entity updates
                 await context.Entities.CallEntityAsync(

--- a/backend/CPS.ComplexCases.FileTransfer.API/Durable/Payloads/Domain/TransferEntity.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Durable/Payloads/Domain/TransferEntity.cs
@@ -18,12 +18,14 @@ public class TransferEntity
     public int ProcessedFiles { get; set; }
     public int SuccessfulFiles { get; set; }
     public int FailedFiles { get; set; }
+    public int SkippedFiles { get; set; }
     public DateTime? StartedAt { get; set; } = DateTime.UtcNow;
     public DateTime? CompletedAt { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
     public List<TransferItem> SuccessfulItems { get; set; } = new List<TransferItem>();
     public List<TransferFailedItem> FailedItems { get; set; } = new List<TransferFailedItem>();
+    public List<TransferItem> SkippedItems { get; set; } = new List<TransferItem>();
     public List<DeletionError> DeletionErrors { get; set; } = new List<DeletionError>();
     public bool? IsRetry { get; set; } = false;
     public bool? MovedFilesDeletedSuccessfully { get; set; } = false;

--- a/backend/CPS.ComplexCases.FileTransfer.API/Durable/Payloads/Domain/TransferResult.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Durable/Payloads/Domain/TransferResult.cs
@@ -1,4 +1,3 @@
-
 namespace CPS.ComplexCases.FileTransfer.API.Durable.Payloads.Domain;
 
 /// <summary>
@@ -7,6 +6,8 @@ namespace CPS.ComplexCases.FileTransfer.API.Durable.Payloads.Domain;
 public class TransferResult
 {
     public bool IsSuccess { get; set; }
+    public bool IsSkipped { get; set; }
     public TransferItem? SuccessfulItem { get; set; }
+    public TransferItem? SkippedItem { get; set; }
     public TransferFailedItem? FailedItem { get; set; }
 }

--- a/backend/CPS.ComplexCases.FileTransfer.API/Durable/State/TransferState.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Durable/State/TransferState.cs
@@ -50,6 +50,14 @@ public class TransferEntityState : TaskEntity<TransferEntity>
         State.UpdatedAt = DateTime.UtcNow;
     }
 
+    public void AddSkippedItem(TransferItem skippedItem)
+    {
+        State.SkippedItems.Add(skippedItem);
+        State.SkippedFiles++;
+        State.ProcessedFiles++;
+        State.UpdatedAt = DateTime.UtcNow;
+    }
+
     public void DeleteMovedItemsCompleted(List<DeletionError> failedToDeleteItems)
     {
         State.MovedFilesDeletedSuccessfully = failedToDeleteItems.Count == 0;

--- a/backend/CPS.ComplexCases.FileTransfer.API/Models/Domain/Enums/TransferItemStatus.cs
+++ b/backend/CPS.ComplexCases.FileTransfer.API/Models/Domain/Enums/TransferItemStatus.cs
@@ -6,5 +6,6 @@ namespace CPS.ComplexCases.FileTransfer.API.Models.Domain.Enums;
 public enum TransferItemStatus
 {
     Completed,
-    Failed
+    Failed,
+    Skipped
 }

--- a/ui-spa/src/common/utils/getGroupedActivityFilePaths.test.ts
+++ b/ui-spa/src/common/utils/getGroupedActivityFilePaths.test.ts
@@ -23,28 +23,34 @@ describe("getGroupedActivityFilePaths", () => {
 
     const expectedResult = {
       "": {
-        success: [{ fileName: "file1.pdf" }],
         errors: [{ fileName: "file9.pdf" }],
+        skipped: [],
+        success: [{ fileName: "file1.pdf" }],
       },
       folder1: {
-        success: [{ fileName: "file1.pdf" }, { fileName: "file2.pdf" }],
         errors: [{ fileName: "file6.pdf" }],
+        skipped: [],
+        success: [{ fileName: "file1.pdf" }, { fileName: "file2.pdf" }],
       },
       "folder1 > folder2": {
-        success: [{ fileName: "file3.pdf" }],
         errors: [{ fileName: "file7.pdf" }, { fileName: "file8.pdf" }],
+        skipped: [],
+        success: [{ fileName: "file3.pdf" }],
       },
       "folder1 > folder2 > folder3": {
-        success: [{ fileName: "file3.pdf" }, { fileName: "file4.pdf" }],
         errors: [{ fileName: "file9.pdf" }],
+        skipped: [],
+        success: [{ fileName: "file3.pdf" }, { fileName: "file4.pdf" }],
       },
       folder3: {
-        success: [{ fileName: "file4.pdf" }],
         errors: [],
+        skipped: [],
+        success: [{ fileName: "file4.pdf" }],
       },
       folder5: {
-        success: [],
         errors: [{ fileName: "file11.pdf" }],
+        skipped: [],
+        success: [],
       },
     };
 
@@ -65,8 +71,9 @@ describe("getGroupedActivityFilePaths", () => {
 
     const expectedResult = {
       "folder1 > subfolder": {
-        success: [{ fileName: "file1.txt" }],
         errors: [{ fileName: "file2.txt" }, { fileName: "file3.txt" }],
+        skipped: [],
+        success: [{ fileName: "file1.txt" }],
       },
     };
 
@@ -90,14 +97,16 @@ describe("getGroupedActivityFilePaths", () => {
 
     const expectedResult = {
       "": {
+        errors: [],
+        skipped: [],
         success: [
           { fileName: "generated-100MB-2026-02-12-01-41-46-file1.txt" },
         ],
-        errors: [],
       },
       "abc.1": {
-        success: [],
         errors: [{ fileName: "generated-100MB-2026-02-12-01-41-46-file2.txt" }],
+        skipped: [],
+        success: [],
       },
     };
 
@@ -134,28 +143,32 @@ describe("getGroupedActivityFilePaths", () => {
 
     const expectedResult = {
       "": {
+        errors: [],
+        skipped: [],
         success: [
           { fileName: "generated-100MB-2026-02-12-01-41-46-file1.txt" },
         ],
-        errors: [],
       },
       "4. Served Evidence": {
+        errors: [{ fileName: "generated-100MB-2026-02-12-01-41-46-file5.txt" }],
+        skipped: [],
         success: [
           { fileName: "generated-100MB-2026-02-12-01-41-46-file2.txt" },
         ],
-        errors: [{ fileName: "generated-100MB-2026-02-12-01-41-46-file5.txt" }],
       },
       "4. Served Evidence > abc3": {
+        errors: [],
+        skipped: [],
         success: [
           { fileName: "generated-100MB-2026-02-12-01-41-46-file7.txt" },
         ],
-        errors: [],
       },
       "Served Evidence2 > abc3": {
+        errors: [{ fileName: "generated-100MB-2026-02-12-01-41-46-file6.txt" }],
+        skipped: [],
         success: [
           { fileName: "generated-100MB-2026-02-12-01-41-46-file3.txt" },
         ],
-        errors: [{ fileName: "generated-100MB-2026-02-12-01-41-46-file6.txt" }],
       },
     };
 
@@ -192,33 +205,59 @@ describe("getGroupedActivityFilePaths", () => {
 
     const expectedResult = {
       "": {
+        errors: [],
+        skipped: [],
         success: [
           { fileName: "generated-100MB-2026-02-12-01-41-46-file1.txt" },
         ],
-        errors: [],
       },
       "4. Served Evidence": {
+        errors: [{ fileName: "generated-100MB-2026-02-12-01-41-46-file5.txt" }],
+        skipped: [],
         success: [
           { fileName: "generated-100MB-2026-02-12-01-41-46-file2.txt" },
         ],
-        errors: [{ fileName: "generated-100MB-2026-02-12-01-41-46-file5.txt" }],
       },
       "4. Served Evidence > abc3": {
+        errors: [],
+        skipped: [],
         success: [
           { fileName: "generated-100MB-2026-02-12-01-41-46-file7.txt" },
         ],
-        errors: [],
       },
       "Served Evidence2 > abc3": {
+        errors: [{ fileName: "generated-100MB-2026-02-12-01-41-46-file6.txt" }],
+        skipped: [],
         success: [
           { fileName: "generated-100MB-2026-02-12-01-41-46-file3.txt" },
         ],
-        errors: [{ fileName: "generated-100MB-2026-02-12-01-41-46-file6.txt" }],
       },
     };
 
     expect(
       getGroupedActivityFilePaths(successFiles, failedFiles, sourcePath),
     ).toStrictEqual(expectedResult);
+  });
+
+  test("should group skipped files with a Skipped outcome", () => {
+    const successFiles = [{ path: "abc/file1.pdf" }];
+    const failedFiles: { path: string }[] = [];
+    const skippedFiles = [{ path: "abc/empty.txt" }];
+    const sourcePath = "abc";
+
+    expect(
+      getGroupedActivityFilePaths(
+        successFiles,
+        failedFiles,
+        sourcePath,
+        skippedFiles,
+      ),
+    ).toStrictEqual({
+      "": {
+        errors: [],
+        skipped: [{ fileName: "empty.txt" }],
+        success: [{ fileName: "file1.pdf" }],
+      },
+    });
   });
 });

--- a/ui-spa/src/common/utils/getGroupedActivityFilePaths.ts
+++ b/ui-spa/src/common/utils/getGroupedActivityFilePaths.ts
@@ -2,13 +2,21 @@ import { getCleanPath } from "./getCleanPath";
 
 export type ActivityRelativePathFileType = {
   errors: { fileName: string }[];
+  skipped: { fileName: string }[];
   success: { fileName: string }[];
+};
+
+type GroupedFilePath = {
+  relativePath: string;
+  fileName: string;
+  outcome: "failed" | "skipped" | "success";
 };
 
 export const getGroupedActivityFilePaths = (
   successFiles: { path: string }[],
   failedFiles: { path: string }[],
   sourcePath: string,
+  skippedFiles: { path: string }[] = [],
 ) => {
   const getRelativePathAndFileName = (
     sourcePartsLength: number,
@@ -24,47 +32,43 @@ export const getGroupedActivityFilePaths = (
   const cleanSourcePath = getCleanPath(sourcePath);
   const sourcePathParts = cleanSourcePath ? cleanSourcePath.split("/") : [];
 
-  const successFilePaths = successFiles.map(({ path }) => ({
-    hasFailed: false,
+  const successFilePaths: GroupedFilePath[] = successFiles.map(({ path }) => ({
+    outcome: "success",
     ...getRelativePathAndFileName(sourcePathParts.length, path),
   }));
 
-  const failedFilePaths = failedFiles.map(({ path }) => ({
-    hasFailed: true,
+  const failedFilePaths: GroupedFilePath[] = failedFiles.map(({ path }) => ({
+    outcome: "failed",
     ...getRelativePathAndFileName(sourcePathParts.length, path),
   }));
 
-  const groupedFiles = [...failedFilePaths, ...successFilePaths].reduce(
+  const skippedFilePaths: GroupedFilePath[] = skippedFiles.map(({ path }) => ({
+    outcome: "skipped",
+    ...getRelativePathAndFileName(sourcePathParts.length, path),
+  }));
+
+  const groupedFiles = [
+    ...failedFilePaths,
+    ...skippedFilePaths,
+    ...successFilePaths,
+  ].reduce(
     (acc, curr) => {
       if (!acc[curr.relativePath]) {
-        const value: ActivityRelativePathFileType = {
+        acc[curr.relativePath] = {
           errors: [],
+          skipped: [],
           success: [],
         };
-        if (curr.hasFailed) {
-          value.errors = [
-            {
-              fileName: curr.fileName,
-            },
-          ];
-        } else {
-          value.success = [
-            {
-              fileName: curr.fileName,
-            },
-          ];
-        }
-        acc[curr.relativePath] = value;
-        return acc;
       }
-      if (curr.hasFailed)
-        acc[curr.relativePath].errors.push({
-          fileName: curr.fileName,
-        });
-      else
-        acc[curr.relativePath].success.push({
-          fileName: curr.fileName,
-        });
+
+      if (curr.outcome === "failed") {
+        acc[curr.relativePath].errors.push({ fileName: curr.fileName });
+      } else if (curr.outcome === "skipped") {
+        acc[curr.relativePath].skipped.push({ fileName: curr.fileName });
+      } else {
+        acc[curr.relativePath].success.push({ fileName: curr.fileName });
+      }
+
       return acc;
     },
     {} as Record<string, ActivityRelativePathFileType>,

--- a/ui-spa/src/common/utils/getTransferActivityStatusTagData.test.ts
+++ b/ui-spa/src/common/utils/getTransferActivityStatusTagData.test.ts
@@ -79,6 +79,7 @@ describe("getTransferActivityStatusTagData", () => {
         details: {
           ...activity.details!,
           transferedFileCount: 0,
+          skippedFileCount: 0,
         },
       }),
     ).toEqual({ color: "red", name: "Failed" });
@@ -92,10 +93,30 @@ describe("getTransferActivityStatusTagData", () => {
           ...activity.details!,
           transferedFileCount: 6,
           errorFileCount: 0,
+          skippedFileCount: 0,
         },
       }),
     ).toEqual({ color: "green", name: "Completed" });
   });
+
+  it("Should return Completed when only empty files were skipped", () => {
+    expect(
+      getTransferActivityStatusTagData({
+        ...activity,
+        details: {
+          ...activity.details!,
+          totalFiles: 1,
+          transferedFileCount: 0,
+          errorFileCount: 0,
+          skippedFileCount: 1,
+          files: [],
+          errors: [],
+          skipped: [{ path: "shared/empty.txt" }],
+        },
+      }),
+    ).toEqual({ color: "green", name: "Completed" });
+  });
+
   it("Should return Completed with errors tag name and green yellow when the there are non zero transferred file count and non zero error file count ", () => {
     expect(
       getTransferActivityStatusTagData({

--- a/ui-spa/src/common/utils/getTransferActivityStatusTagData.ts
+++ b/ui-spa/src/common/utils/getTransferActivityStatusTagData.ts
@@ -15,17 +15,17 @@ export const getTransferActivityStatusTagData = (
   if (!isTransferDetails(activity.details)) return null;
 
   const { details } = activity;
+  const skippedFileCount = details.skippedFileCount ?? 0;
+  const accountedFor = details.transferedFileCount + skippedFileCount;
 
-  if (!details.transferedFileCount)
+  // Skip-only batches (e.g. empty files to Egress) still complete successfully.
+  if (!accountedFor)
     return {
       name: "Failed",
       color: "red",
     };
 
-  if (
-    details.totalFiles === details.transferedFileCount &&
-    !details.errorFileCount
-  )
+  if (details.totalFiles === accountedFor && !details.errorFileCount)
     return {
       name: "Completed",
       color: "green",

--- a/ui-spa/src/components/case-management/activity-log/ActivityTimeline.tsx
+++ b/ui-spa/src/components/case-management/activity-log/ActivityTimeline.tsx
@@ -119,13 +119,16 @@ export const ActivityTimeline: React.FC<ActivityTimelineProps> = ({
         </div>
       </div>
 
-      {(!!details.files.length || !!details.errors.length) && (
+      {(!!details.files.length ||
+        !!details.errors.length ||
+        !!details.skipped?.length) && (
         <div>
           <p>Below is a list of documents/folders copied:</p>
           <Details summaryChildren="View files">
             <RelativePathFiles
               successFiles={details.files}
               errorFiles={details.errors}
+              skippedFiles={details.skipped}
               sourcePath={details.sourcePath}
               name="activity"
             />

--- a/ui-spa/src/components/case-management/activity-log/RelativePathFiles.tsx
+++ b/ui-spa/src/components/case-management/activity-log/RelativePathFiles.tsx
@@ -8,6 +8,7 @@ import styles from "./RelativePathFiles.module.scss";
 type RelativePathFilesProps = {
   successFiles: { path: string }[];
   errorFiles: { path: string }[];
+  skippedFiles?: { path: string }[];
   sourcePath: string;
   name: string;
 };
@@ -15,17 +16,29 @@ type RelativePathFilesProps = {
 const RelativePathFiles: React.FC<RelativePathFilesProps> = ({
   successFiles,
   errorFiles,
+  skippedFiles = [],
   sourcePath,
   name,
 }) => {
   const groupedFiles = useMemo(
-    () => getGroupedActivityFilePaths(successFiles, errorFiles, sourcePath),
-    [successFiles, errorFiles, sourcePath],
+    () =>
+      getGroupedActivityFilePaths(
+        successFiles,
+        errorFiles,
+        sourcePath,
+        skippedFiles,
+      ),
+    [successFiles, errorFiles, skippedFiles, sourcePath],
   );
 
   return (
     <div data-testid={`${name}-files`}>
       {sortRelativePaths(Object.keys(groupedFiles)).map((key) => {
+        const group = groupedFiles[`${key}`];
+        const hasErrors = !!group.errors.length;
+        const hasSkipped = !!group.skipped.length;
+        const hasSuccess = !!group.success.length;
+
         return (
           <section key={key}>
             <div
@@ -36,9 +49,9 @@ const RelativePathFiles: React.FC<RelativePathFilesProps> = ({
               <span className={styles.relativePathText}>{key}</span>
             </div>
 
-            {!!groupedFiles[`${key}`].errors.length && (
+            {hasErrors && (
               <ul className={styles.list}>
-                {groupedFiles[`${key}`].errors.map((file) => (
+                {group.errors.map((file) => (
                   <li
                     key={`${key}-err-${file.fileName}`}
                     className={styles.listItem}
@@ -62,13 +75,39 @@ const RelativePathFiles: React.FC<RelativePathFilesProps> = ({
                 ))}
               </ul>
             )}
-            {!!groupedFiles[`${key}`].errors.length &&
-              !!groupedFiles[`${key}`].success.length && (
-                <div className={styles.seperator} />
-              )}
-            {!!groupedFiles[`${key}`].success.length && (
+            {hasErrors && (hasSkipped || hasSuccess) && (
+              <div className={styles.seperator} />
+            )}
+            {hasSkipped && (
               <ul className={styles.list}>
-                {groupedFiles[`${key}`].success.map((file) => (
+                {group.skipped.map((file) => (
+                  <li
+                    key={`${key}-skip-${file.fileName}`}
+                    className={styles.listItem}
+                  >
+                    <div className={styles.listContent}>
+                      <Tag
+                        gdsTagColour="yellow"
+                        className={styles.statusTag}
+                        data-testid="character-tag"
+                      >
+                        Skipped
+                      </Tag>{" "}
+                      <div className={styles.fileNameWrapper}>
+                        <FileIcon />
+                        <span className={styles.fileNameText}>
+                          {file.fileName}
+                        </span>
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {hasSkipped && hasSuccess && <div className={styles.seperator} />}
+            {hasSuccess && (
+              <ul className={styles.list}>
+                {group.success.map((file) => (
                   <li
                     key={`${key}-ok-${file.fileName}`}
                     className={styles.listItem}

--- a/ui-spa/src/schemas/responses/activityLogResponse.ts
+++ b/ui-spa/src/schemas/responses/activityLogResponse.ts
@@ -37,14 +37,13 @@ export const transferDetailsSchema = z.object({
   transferType: z.enum(["Move", "Copy"]),
   errorFileCount: z.number(),
   transferedFileCount: z.number(),
-  skippedFileCount: z.number().optional().default(0),
+  skippedFileCount: z.number().optional(),
   totalFiles: z.number(),
   files: z.array(z.object({ path: z.string() })),
   errors: z.array(z.object({ path: z.string() })),
   skipped: z
     .array(z.object({ path: z.string(), errorMessage: z.string().optional() }))
-    .optional()
-    .default([]),
+    .optional(),
   deletionErrors: z.array(z.object({ path: z.string() })),
 });
 

--- a/ui-spa/src/schemas/responses/activityLogResponse.ts
+++ b/ui-spa/src/schemas/responses/activityLogResponse.ts
@@ -37,9 +37,14 @@ export const transferDetailsSchema = z.object({
   transferType: z.enum(["Move", "Copy"]),
   errorFileCount: z.number(),
   transferedFileCount: z.number(),
+  skippedFileCount: z.number().optional().default(0),
   totalFiles: z.number(),
   files: z.array(z.object({ path: z.string() })),
   errors: z.array(z.object({ path: z.string() })),
+  skipped: z
+    .array(z.object({ path: z.string(), errorMessage: z.string().optional() }))
+    .optional()
+    .default([]),
   deletionErrors: z.array(z.object({ path: z.string() })),
 });
 

--- a/ui-spa/src/schemas/responses/transferStatusResponse.ts
+++ b/ui-spa/src/schemas/responses/transferStatusResponse.ts
@@ -10,6 +10,12 @@ export const transferFailedItemSchema = z.object({
   ]),
 });
 
+export const transferSkippedItemSchema = z.object({
+  sourcePath: z.string(),
+  size: z.number().optional(),
+  reason: z.string().optional(),
+});
+
 export const transferStatusResponseSchema = z.object({
   id: z.string().uuid(),
   status: z.enum([
@@ -29,11 +35,13 @@ export const transferStatusResponseSchema = z.object({
   processedFiles: z.number(),
   successfulFiles: z.number(),
   failedFiles: z.number(),
+  skippedFiles: z.number().optional().default(0),
   successfulItems: z.array(
     z.object({
       sourcePath: z.string(),
     }),
   ),
+  skippedItems: z.array(transferSkippedItemSchema).optional().default([]),
   destinationPath: z.string(),
 });
 

--- a/ui-spa/src/schemas/responses/transferStatusResponse.ts
+++ b/ui-spa/src/schemas/responses/transferStatusResponse.ts
@@ -35,13 +35,13 @@ export const transferStatusResponseSchema = z.object({
   processedFiles: z.number(),
   successfulFiles: z.number(),
   failedFiles: z.number(),
-  skippedFiles: z.number().optional().default(0),
+  skippedFiles: z.number().optional(),
   successfulItems: z.array(
     z.object({
       sourcePath: z.string(),
     }),
   ),
-  skippedItems: z.array(transferSkippedItemSchema).optional().default([]),
+  skippedItems: z.array(transferSkippedItemSchema).optional(),
   destinationPath: z.string(),
 });
 


### PR DESCRIPTION
# PR checklist

Tick what applies before you raise. Delete anything that doesn't.

## Correctness
- [x] Does what the ticket asks for
- [x] Handles the edge cases (empty, null, zero, large inputs), not just the happy path
- [x] Errors are handled, not swallowed
- [x] New logic has tests, including the failure cases
- [x] Tests assert something real, not just run the code

## Keeping it simple
- [x] Doesn't rebuild something that already exists in the codebase
- [x] No more complex or slower than it needs to be
- [x] No leftover debug logging or commented-out code

## Easy to miss (a green pipeline won't flag these)
- [x] One logical change, not a pile of unrelated stuff

### If you touched the backend
- [x] Schema changes have a migration, and the Down() doesn't drop anything it shouldn't
- [x] New app settings are wired into the fa-config templates
- [x] Secrets use Key Vault references, not plain text
- [x] New outbound HTTP clients go through the shared resilience handler (AddResiliencePolicyHandler), rather than hand-rolling retries
- [x] New calls to an external service (DDEI, Egress, NetApp) have client tests against a WireMock stub (for the serialisation, auth and error handling) and are covered by the integration tests that run against the real dev services
- [x] Ran dotnet format, since CI builds and tests but doesn't check formatting

### If you touched the UI
- [x] Ran the e2e/ suite locally (the PR build only runs the mocked tests; the full suite runs post-merge and gates the deploy)
- [x] API changes are reflected in the MSW handlers in src/mocks and the matching zod schema, so the mocked tests aren't passing against a contract that's gone
- [x] New config or feature flags are wired into the VITE build variables, not just added in code
- [x] Data fetches handle the loading, empty and error states, not just success, and match how the rest of the app already does it
- [x] Ran prettier (npm run prettier:format), since CI lints but doesn't check formatting
- [x] Checked accessibility (keyboard nav, screen reader, sensible labels), since the Lighthouse run is manual and won't flag it for you