### PR TITLE
enable UI V1 in E2E tests

### DIFF
--- a/devops-pipelines/move-playwright-test.yml
+++ b/devops-pipelines/move-playwright-test.yml
@@ -54,11 +54,7 @@ jobs:
         displayName: "Run E2E Tests"
         env:
           CI: true
-          # Staging renders the v1 ("Shared Drive") transfer screen for the E2E
-          # user, so drive it with the v1 page object. Without this the tests
-          # default to the old screen and the Egress panel never reads its rows
-          # (file appears in the UI but the old-screen selectors miss it).
-          TRANSFER_MATERIALS_V1: true
+          TRANSFER_MATERIALS_V1: true # Staging renders the v1 ("Shared Drive") transfer screen for the E2E user
           TEST_FILE_SIZE_MB: ${{ parameters.testFileSizeMb }}
           BASE_URL: $(RedirectUrlLccUi)
           CMS_LOGIN_PAGE: "$(LccApiBaseUrl)/api/tactical/login"

--- a/devops-pipelines/templates/e2e-playwright-test-job.yml
+++ b/devops-pipelines/templates/e2e-playwright-test-job.yml
@@ -23,6 +23,8 @@ jobs:
         value: "20.x"
       - name: workingDir
         value: "$(System.DefaultWorkingDirectory)/e2e/pw"
+      - name: transferMaterialsV1 # Staging renders the v1 ("Shared Drive") transfer screen for the E2E user.
+        value: ${{ ne(parameters.environment, 'dev') }}
 
     steps:
       - task: UseNode@1
@@ -45,6 +47,7 @@ jobs:
         displayName: "Run E2E Tests"
         env:
           CI: true
+          TRANSFER_MATERIALS_V1: $(transferMaterialsV1)
           BASE_URL: $(RedirectUrlLccUi)
           CMS_LOGIN_PAGE: "$(LccApiBaseUrl)/api/tactical/login"
           EGRESS_BASE_URL: $(EgressOptionsUrl)


### PR DESCRIPTION
Handle the difference in UI versions between environments in E2E playwright tests

# PR checklist
## Keeping it simple
- [x] Doesn't rebuild something that already exists in the codebase
- [x] No more complex or slower than it needs to be
- [x] No leftover debug logging or commented-out code

## Easy to miss (a green pipeline won't flag these)
- [x] One logical change, not a pile of unrelated stuff
