### PR TITLE
egress and netapp path fix

### DIFF
--- a/backend/CPS.ComplexCases.API/Domain/Response/CaseWithMetadataResponse.cs
+++ b/backend/CPS.ComplexCases.API/Domain/Response/CaseWithMetadataResponse.cs
@@ -16,6 +16,8 @@ public class CaseWithMetadataResponse
   public string? RegistrationDate { get; set; }
   [JsonPropertyName("egressWorkspaceId")]
   public string? EgressWorkspaceId { get; set; }
+  [JsonPropertyName("egressWorkspaceName")]
+  public string? EgressWorkspaceName { get; set; }
   [JsonPropertyName("netappFolderPath")]
   public string? NetappFolderPath { get; set; }
   [JsonPropertyName("activeTransferId")]

--- a/backend/CPS.ComplexCases.API/Functions/GetCase.cs
+++ b/backend/CPS.ComplexCases.API/Functions/GetCase.cs
@@ -68,6 +68,7 @@ public class GetCase(ILogger<GetCase> logger,
         {
             CaseId = caseResponse.CaseId,
             EgressWorkspaceId = caseResponse.EgressWorkspaceId,
+            EgressWorkspaceName = caseResponse.EgressWorkspaceName,
             NetappFolderPath = caseResponse.NetappFolderPath,
             Urn = cmsResponse.Urn,
             OperationName = cmsResponse.OperationName,

--- a/ui-spa/playwright/integration-tests/transfer-material-meta-data-issues.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-material-meta-data-issues.spec.ts
@@ -12,7 +12,7 @@ test.describe("egress meta data issues", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -53,7 +53,7 @@ test.describe("egress meta data issues", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -210,7 +210,7 @@ test.describe("netapp meta data issues", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -364,7 +364,7 @@ test.describe("netapp meta data issues", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: null,
           leadDefendantName: "John Doe",
@@ -387,7 +387,7 @@ test.describe("netapp meta data issues", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",

--- a/ui-spa/playwright/integration-tests/transfer-material-meta-data-issues.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-material-meta-data-issues.spec.ts
@@ -12,6 +12,7 @@ test.describe("egress meta data issues", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -52,6 +53,7 @@ test.describe("egress meta data issues", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -208,6 +210,7 @@ test.describe("netapp meta data issues", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -361,6 +364,7 @@ test.describe("netapp meta data issues", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: null,
           leadDefendantName: "John Doe",
@@ -383,6 +387,7 @@ test.describe("netapp meta data issues", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",

--- a/ui-spa/playwright/integration-tests/transfer-material-v0/egress-netapp-transfer.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-material-v0/egress-netapp-transfer.spec.ts
@@ -534,6 +534,7 @@ test.describe("egress-netapp-transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -695,6 +696,7 @@ test.describe("egress-netapp-transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -912,6 +914,7 @@ test.describe("egress-netapp-transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",

--- a/ui-spa/playwright/integration-tests/transfer-material-v0/egress-netapp-transfer.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-material-v0/egress-netapp-transfer.spec.ts
@@ -534,7 +534,7 @@ test.describe("egress-netapp-transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -696,7 +696,7 @@ test.describe("egress-netapp-transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -914,7 +914,7 @@ test.describe("egress-netapp-transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",

--- a/ui-spa/playwright/integration-tests/transfer-material-v0/netapp-egress-transfer.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-material-v0/netapp-egress-transfer.spec.ts
@@ -424,7 +424,7 @@ test.describe("netapp-egress-transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -586,7 +586,7 @@ test.describe("netapp-egress-transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -714,7 +714,7 @@ test.describe("netapp-egress-transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",

--- a/ui-spa/playwright/integration-tests/transfer-material-v0/netapp-egress-transfer.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-material-v0/netapp-egress-transfer.spec.ts
@@ -424,6 +424,7 @@ test.describe("netapp-egress-transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -585,6 +586,7 @@ test.describe("netapp-egress-transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -712,6 +714,7 @@ test.describe("netapp-egress-transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer-indexing-error.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer-indexing-error.spec.ts
@@ -36,7 +36,7 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
     }
     if (isRootFolder) {
       await transferMaterialsSourcePage.verifyFolderPath([
-        "Egress: Thunderstruck",
+        "Egress: Workspace-Alpha",
       ]);
       await transferMaterialsSourcePage.handleFolderClick("folder-1-0");
       await transferMaterialsSourcePage.verifyTransferSourceTableLoader(
@@ -49,7 +49,7 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
       );
     }
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
       "folder-1-0",
     ]);
 

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer-indexing-error.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer-indexing-error.spec.ts
@@ -71,7 +71,7 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
       transferType,
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
       true,
       ["folder-1-0", "folder-1-1"],
     );

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer-indexing-error.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer-indexing-error.spec.ts
@@ -71,7 +71,7 @@ test.describe("egress-netapp-transfer-indexing-error", () => {
       transferType,
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
       true,
       ["folder-1-0", "folder-1-1"],
     );

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer.spec.ts
@@ -16,7 +16,7 @@ async function runTransferScenario(page: Page, transferType: "copy" | "move") {
     "egress",
     false,
   );
-  await transferMaterialsSourcePage.verifyFolderPath(["Egress: Thunderstruck"]);
+  await transferMaterialsSourcePage.verifyFolderPath(["Egress: Workspace-Alpha"]);
   await transferMaterialsSourcePage.validateTableColumnHeaders();
 
   const folderRows = [
@@ -38,7 +38,7 @@ async function runTransferScenario(page: Page, transferType: "copy" | "move") {
     false,
   );
   await transferMaterialsSourcePage.verifyFolderPath([
-    "Egress: Thunderstruck",
+    "Egress: Workspace-Alpha",
     "folder-1-0",
   ]);
   await transferMaterialsSourcePage.validateTableRowValues([
@@ -193,7 +193,7 @@ test.describe("transfer material egress netapp transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -357,7 +357,7 @@ test.describe("transfer material egress netapp transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -490,7 +490,7 @@ test.describe("transfer material egress netapp transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer.spec.ts
@@ -71,23 +71,23 @@ async function runTransferScenario(page: Page, transferType: "copy" | "move") {
     transferType,
   );
   await transferMaterialsDestinationPage.verifyFolderExpanded(
-    "Shared Drive: netapp/",
+    "Shared Drive: netapp",
     true,
     ["folder-1-0", "folder-1-1"],
   );
   await transferMaterialsDestinationPage.clickMinimizeFolder(
-    "Shared Drive: netapp/",
+    "Shared Drive: netapp",
   );
   await transferMaterialsDestinationPage.verifyFolderExpanded(
-    "Shared Drive: netapp/",
+    "Shared Drive: netapp",
     false,
     [],
   );
   await transferMaterialsDestinationPage.clickExpandFolder(
-    "Shared Drive: netapp/",
+    "Shared Drive: netapp",
   );
   await transferMaterialsDestinationPage.verifyFolderExpanded(
-    "Shared Drive: netapp/",
+    "Shared Drive: netapp",
     true,
     ["folder-1-0", "folder-1-1"],
   );

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/egress-netapp-transfer.spec.ts
@@ -71,23 +71,23 @@ async function runTransferScenario(page: Page, transferType: "copy" | "move") {
     transferType,
   );
   await transferMaterialsDestinationPage.verifyFolderExpanded(
-    "Shared Drive: Thunderstruck",
+    "Shared Drive: netapp/",
     true,
     ["folder-1-0", "folder-1-1"],
   );
   await transferMaterialsDestinationPage.clickMinimizeFolder(
-    "Shared Drive: Thunderstruck",
+    "Shared Drive: netapp/",
   );
   await transferMaterialsDestinationPage.verifyFolderExpanded(
-    "Shared Drive: Thunderstruck",
+    "Shared Drive: netapp/",
     false,
     [],
   );
   await transferMaterialsDestinationPage.clickExpandFolder(
-    "Shared Drive: Thunderstruck",
+    "Shared Drive: netapp/",
   );
   await transferMaterialsDestinationPage.verifyFolderExpanded(
-    "Shared Drive: Thunderstruck",
+    "Shared Drive: netapp/",
     true,
     ["folder-1-0", "folder-1-1"],
   );
@@ -193,6 +193,7 @@ test.describe("transfer material egress netapp transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -356,6 +357,7 @@ test.describe("transfer material egress netapp transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -488,6 +490,7 @@ test.describe("transfer material egress netapp transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/netapp-egress-transfer.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/netapp-egress-transfer.spec.ts
@@ -62,7 +62,7 @@ test.describe("transfer material netapp to egress transfer", () => {
     await transferMaterialsSourcePage.clickToggleTransferDirection();
 
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
     ]);
     await transferMaterialsSourcePage.validateTableColumnHeaders();
 
@@ -88,7 +88,7 @@ test.describe("transfer material netapp to egress transfer", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
       "folder-1-0",
     ]);
     await transferMaterialsSourcePage.validateTableRowValues([
@@ -189,6 +189,7 @@ test.describe("transfer material netapp to egress transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -351,6 +352,7 @@ test.describe("transfer material netapp to egress transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -469,6 +471,7 @@ test.describe("transfer material netapp to egress transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/netapp-egress-transfer.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/netapp-egress-transfer.spec.ts
@@ -57,7 +57,7 @@ test.describe("transfer material netapp to egress transfer", () => {
     await transferMaterialsSourcePage.verifyEgressTransferSourceElements();
 
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
     ]);
     await transferMaterialsSourcePage.clickToggleTransferDirection();
 
@@ -115,26 +115,26 @@ test.describe("transfer material netapp to egress transfer", () => {
       "copy",
     );
     await transferMaterialsDestinationPage.verifyDisabledTreeItem(
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
       true,
       ["folder-1-0", "folder-1-1"],
     );
     await transferMaterialsDestinationPage.clickMinimizeFolder(
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
       false,
       [],
     );
     await transferMaterialsDestinationPage.clickExpandFolder(
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
       true,
       ["folder-1-0", "folder-1-1"],
     );
@@ -189,7 +189,7 @@ test.describe("transfer material netapp to egress transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -352,7 +352,7 @@ test.describe("transfer material netapp to egress transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",
@@ -471,7 +471,7 @@ test.describe("transfer material netapp to egress transfer", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: "Thunderstruck",
           leadDefendantName: "John Doe",

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/netapp-egress-transfer.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/netapp-egress-transfer.spec.ts
@@ -62,7 +62,7 @@ test.describe("transfer material netapp to egress transfer", () => {
     await transferMaterialsSourcePage.clickToggleTransferDirection();
 
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
     ]);
     await transferMaterialsSourcePage.validateTableColumnHeaders();
 
@@ -88,7 +88,7 @@ test.describe("transfer material netapp to egress transfer", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
       "folder-1-0",
     ]);
     await transferMaterialsSourcePage.validateTableRowValues([

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/skipLinkv1.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/skipLinkv1.spec.ts
@@ -71,7 +71,7 @@ test.describe("Transfer v1 skip link test ", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
       "folder-1-0",
     ]);
     await transferMaterialsSourcePage.toggleCheckbox(0);
@@ -193,7 +193,7 @@ test.describe("Transfer v1 skip link test ", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
       "folder-1-0",
     ]);
     await transferMaterialsSourcePage.toggleCheckbox(0);

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-error-handling.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-error-handling.spec.ts
@@ -63,7 +63,7 @@ test.describe("transfer-error-handling", () => {
       "copy",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
       true,
       ["folder-1-0", "folder-1-1"],
     );
@@ -117,7 +117,7 @@ test.describe("transfer-error-handling", () => {
       "copy",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
       true,
       ["folder-1-0", "folder-1-1"],
     );
@@ -169,7 +169,7 @@ test.describe("transfer-error-handling", () => {
       "copy",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
       true,
       ["folder-1-0", "folder-1-1"],
     );
@@ -228,7 +228,7 @@ test.describe("transfer-error-handling", () => {
       "copy",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
       true,
       ["folder-1-0", "folder-1-1"],
     );
@@ -280,7 +280,7 @@ test.describe("transfer-error-handling", () => {
       "copy",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
       true,
       ["folder-1-0", "folder-1-1"],
     );

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-error-handling.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-error-handling.spec.ts
@@ -19,7 +19,7 @@ test.describe("transfer-error-handling", () => {
     await transferMaterialsSourcePage.verifyEgressTransferSourceElements();
 
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
     ]);
     await transferMaterialsSourcePage.handleFolderClick("folder-1-0");
     await transferMaterialsSourcePage.verifyTransferSourceTableLoader(
@@ -31,7 +31,7 @@ test.describe("transfer-error-handling", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
       "folder-1-0",
     ]);
   });

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-error-handling.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-error-handling.spec.ts
@@ -63,7 +63,7 @@ test.describe("transfer-error-handling", () => {
       "copy",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
       true,
       ["folder-1-0", "folder-1-1"],
     );
@@ -117,7 +117,7 @@ test.describe("transfer-error-handling", () => {
       "copy",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
       true,
       ["folder-1-0", "folder-1-1"],
     );
@@ -169,7 +169,7 @@ test.describe("transfer-error-handling", () => {
       "copy",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
       true,
       ["folder-1-0", "folder-1-1"],
     );
@@ -228,7 +228,7 @@ test.describe("transfer-error-handling", () => {
       "copy",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
       true,
       ["folder-1-0", "folder-1-1"],
     );
@@ -280,7 +280,7 @@ test.describe("transfer-error-handling", () => {
       "copy",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
       true,
       ["folder-1-0", "folder-1-1"],
     );

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-error-page.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-error-page.spec.ts
@@ -60,7 +60,7 @@ test.describe("transfer-error-page", () => {
       "copy",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
       true,
       ["folder-1-0", "folder-1-1"],
     );

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-error-page.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-error-page.spec.ts
@@ -60,7 +60,7 @@ test.describe("transfer-error-page", () => {
       "copy",
     );
     await transferMaterialsDestinationPage.verifyFolderExpanded(
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
       true,
       ["folder-1-0", "folder-1-1"],
     );

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-error-page.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-error-page.spec.ts
@@ -30,7 +30,7 @@ test.describe("transfer-error-page", () => {
     await transferMaterialsSourcePage.verifyEgressTransferSourceElements();
 
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
     ]);
     await transferMaterialsSourcePage.handleFolderClick("folder-1-0");
     await transferMaterialsSourcePage.verifyTransferSourceTableLoader(
@@ -42,7 +42,7 @@ test.describe("transfer-error-page", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
       "folder-1-0",
     ]);
 

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-material-egress-list.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-material-egress-list.spec.ts
@@ -157,7 +157,7 @@ test.describe("transfer material egress list", () => {
     await transferMaterialsSourcePage.verifyCheckboxesVisibility(false, 4);
   });
 
-  test("Should show the leadDefendant name in the Home path for Egress if the operation name is null", async ({
+  test("Should show the egress workspace name in the Home path for Egress if the operation name is null", async ({
     page,
     worker,
   }) => {
@@ -167,6 +167,7 @@ test.describe("transfer material egress list", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: null,
           leadDefendantName: "John Doe",
@@ -188,6 +189,8 @@ test.describe("transfer material egress list", () => {
       "egress",
       false,
     );
-    await transferMaterialsSourcePage.verifyFolderPath(["Egress: John Doe"]);
+    await transferMaterialsSourcePage.verifyFolderPath([
+      "Egress: Thunderstruck",
+    ]);
   });
 });

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-material-egress-list.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-material-egress-list.spec.ts
@@ -20,7 +20,7 @@ test.describe("transfer material egress list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
     ]);
     await transferMaterialsSourcePage.validateTableColumnHeaders();
 
@@ -49,7 +49,7 @@ test.describe("transfer material egress list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
     ]);
     await transferMaterialsSourcePage.validateTableColumnHeaders();
 
@@ -69,7 +69,7 @@ test.describe("transfer material egress list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
       "folder-1-0",
     ]);
     await transferMaterialsSourcePage.validateTableRowValues([
@@ -88,7 +88,7 @@ test.describe("transfer material egress list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
       "folder-1-0",
       "folder-2-0",
     ]);
@@ -108,7 +108,7 @@ test.describe("transfer material egress list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
       "folder-1-0",
       "folder-2-0",
       "folder-3-0",
@@ -126,7 +126,7 @@ test.describe("transfer material egress list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
       "folder-1-0",
     ]);
     await transferMaterialsSourcePage.validateTableRowValues([
@@ -136,7 +136,7 @@ test.describe("transfer material egress list", () => {
     ]);
     await transferMaterialsSourcePage.verifyCheckboxesVisibility(true, 4);
     await transferMaterialsSourcePage.handleFolderClick(
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
     );
     await transferMaterialsSourcePage.verifyTransferSourceTableLoader(
       "egress",
@@ -147,7 +147,7 @@ test.describe("transfer material egress list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
     ]);
     await transferMaterialsSourcePage.validateTableRowValues([
       ["", "folder-1-0", "02/01/2000", "--"],
@@ -167,7 +167,7 @@ test.describe("transfer material egress list", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: null,
           leadDefendantName: "John Doe",
@@ -190,7 +190,7 @@ test.describe("transfer material egress list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Egress: Thunderstruck",
+      "Egress: Workspace-Alpha",
     ]);
   });
 });

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-material-netapp-list.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-material-netapp-list.spec.ts
@@ -174,7 +174,7 @@ test.describe("transfer material shared-drive list", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: null,
           leadDefendantName: "John Doe",

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-material-netapp-list.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-material-netapp-list.spec.ts
@@ -20,7 +20,7 @@ test.describe("transfer material shared-drive list", () => {
     );
     await transferMaterialsSourcePage.clickToggleTransferDirection();
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
     ]);
     await transferMaterialsSourcePage.validateTableColumnHeaders();
 
@@ -51,7 +51,7 @@ test.describe("transfer material shared-drive list", () => {
     await transferMaterialsSourcePage.clickToggleTransferDirection();
     await transferMaterialsSourcePage.verifySharedDriveTransferSourceElements();
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
     ]);
     await transferMaterialsSourcePage.validateTableColumnHeaders();
 
@@ -72,7 +72,7 @@ test.describe("transfer material shared-drive list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
       "folder-1-0",
     ]);
     await transferMaterialsSourcePage.validateTableRowValues([
@@ -92,7 +92,7 @@ test.describe("transfer material shared-drive list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
       "folder-1-0",
       "folder-2-0",
     ]);
@@ -113,7 +113,7 @@ test.describe("transfer material shared-drive list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
       "folder-1-0",
       "folder-2-0",
       "folder-3-0",
@@ -131,7 +131,7 @@ test.describe("transfer material shared-drive list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
       "folder-1-0",
     ]);
     await transferMaterialsSourcePage.validateTableRowValues([
@@ -142,7 +142,7 @@ test.describe("transfer material shared-drive list", () => {
     ]);
     await transferMaterialsSourcePage.verifyCheckboxesVisibility(true, 5);
     await transferMaterialsSourcePage.handleFolderClick(
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
     );
     await transferMaterialsSourcePage.verifyTransferSourceTableLoader(
       "shared-drive",
@@ -153,7 +153,7 @@ test.describe("transfer material shared-drive list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: Thunderstruck",
+      "Shared Drive: netapp/",
     ]);
     await transferMaterialsSourcePage.validateTableRowValues([
       ["", "folder-1-0", "--", "--"],
@@ -164,7 +164,7 @@ test.describe("transfer material shared-drive list", () => {
     await transferMaterialsSourcePage.verifyCheckboxesVisibility(true, 5);
   });
 
-  test("Should show the leadDefendant name in the Home path for Shared Drive if the operation name is null", async ({
+  test("Should show the netapp folder path in the Home path for Shared Drive if the operation name is null", async ({
     page,
     worker,
   }) => {
@@ -174,6 +174,7 @@ test.describe("transfer material shared-drive list", () => {
         return HttpResponse.json({
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: null,
           leadDefendantName: "John Doe",
@@ -196,7 +197,7 @@ test.describe("transfer material shared-drive list", () => {
     );
     await transferMaterialsSourcePage.clickToggleTransferDirection();
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: John Doe",
+      "Shared Drive: netapp/",
     ]);
   });
 });

--- a/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-material-netapp-list.spec.ts
+++ b/ui-spa/playwright/integration-tests/transfer-materials-v1/transfer-material-netapp-list.spec.ts
@@ -20,7 +20,7 @@ test.describe("transfer material shared-drive list", () => {
     );
     await transferMaterialsSourcePage.clickToggleTransferDirection();
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
     ]);
     await transferMaterialsSourcePage.validateTableColumnHeaders();
 
@@ -51,7 +51,7 @@ test.describe("transfer material shared-drive list", () => {
     await transferMaterialsSourcePage.clickToggleTransferDirection();
     await transferMaterialsSourcePage.verifySharedDriveTransferSourceElements();
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
     ]);
     await transferMaterialsSourcePage.validateTableColumnHeaders();
 
@@ -72,7 +72,7 @@ test.describe("transfer material shared-drive list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
       "folder-1-0",
     ]);
     await transferMaterialsSourcePage.validateTableRowValues([
@@ -92,7 +92,7 @@ test.describe("transfer material shared-drive list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
       "folder-1-0",
       "folder-2-0",
     ]);
@@ -113,7 +113,7 @@ test.describe("transfer material shared-drive list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
       "folder-1-0",
       "folder-2-0",
       "folder-3-0",
@@ -131,7 +131,7 @@ test.describe("transfer material shared-drive list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
       "folder-1-0",
     ]);
     await transferMaterialsSourcePage.validateTableRowValues([
@@ -142,7 +142,7 @@ test.describe("transfer material shared-drive list", () => {
     ]);
     await transferMaterialsSourcePage.verifyCheckboxesVisibility(true, 5);
     await transferMaterialsSourcePage.handleFolderClick(
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
     );
     await transferMaterialsSourcePage.verifyTransferSourceTableLoader(
       "shared-drive",
@@ -153,7 +153,7 @@ test.describe("transfer material shared-drive list", () => {
       false,
     );
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
     ]);
     await transferMaterialsSourcePage.validateTableRowValues([
       ["", "folder-1-0", "--", "--"],
@@ -197,7 +197,7 @@ test.describe("transfer material shared-drive list", () => {
     );
     await transferMaterialsSourcePage.clickToggleTransferDirection();
     await transferMaterialsSourcePage.verifyFolderPath([
-      "Shared Drive: netapp/",
+      "Shared Drive: netapp",
     ]);
   });
 });

--- a/ui-spa/src/apis/gateway-api.test.ts
+++ b/ui-spa/src/apis/gateway-api.test.ts
@@ -818,7 +818,7 @@ describe("gateway apis", () => {
       const mockData = {
         caseId: 12,
         egressWorkspaceId: "egress_1",
-        egressWorkspaceName: "Thunderstruck",
+        egressWorkspaceName: "Workspace-Alpha",
         netappFolderPath: "netapp/",
         operationName: "Thunderstruck",
         leadDefendantName: "John Doe",
@@ -921,7 +921,7 @@ describe("gateway apis", () => {
         {
           caseId: 12,
           egressWorkspaceId: "egress_1",
-          egressWorkspaceName: "Thunderstruck",
+          egressWorkspaceName: "Workspace-Alpha",
           netappFolderPath: "netapp/",
           operationName: null,
           leadDefendantName: null,

--- a/ui-spa/src/apis/gateway-api.test.ts
+++ b/ui-spa/src/apis/gateway-api.test.ts
@@ -818,6 +818,7 @@ describe("gateway apis", () => {
       const mockData = {
         caseId: 12,
         egressWorkspaceId: "egress_1",
+        egressWorkspaceName: "Thunderstruck",
         netappFolderPath: "netapp/",
         operationName: "Thunderstruck",
         leadDefendantName: "John Doe",
@@ -920,6 +921,7 @@ describe("gateway apis", () => {
         {
           caseId: 12,
           egressWorkspaceId: "egress_1",
+          egressWorkspaceName: "Thunderstruck",
           netappFolderPath: "netapp/",
           operationName: null,
           leadDefendantName: null,

--- a/ui-spa/src/components/case-management/index.tsx
+++ b/ui-spa/src/components/case-management/index.tsx
@@ -100,6 +100,7 @@ const CaseManagementPage = () => {
               caseId={caseId}
               operationName={operationNameOrDefendantName}
               egressWorkspaceId={caseMetaData.egressWorkspaceId}
+              egressWorkspaceName={caseMetaData.egressWorkspaceName ?? ""}
               netAppPath={caseMetaData.netappFolderPath}
               activeTransferId={
                 routeState?.transferId ?? caseMetaData.activeTransferId ?? ""

--- a/ui-spa/src/components/case-management/index.tsx
+++ b/ui-spa/src/components/case-management/index.tsx
@@ -100,7 +100,10 @@ const CaseManagementPage = () => {
               caseId={caseId}
               operationName={operationNameOrDefendantName}
               egressWorkspaceId={caseMetaData.egressWorkspaceId}
-              egressWorkspaceName={caseMetaData.egressWorkspaceName ?? ""}
+              egressWorkspaceName={
+                caseMetaData.egressWorkspaceName ||
+                operationNameOrDefendantName
+              }
               netAppPath={caseMetaData.netappFolderPath}
               activeTransferId={
                 routeState?.transferId ?? caseMetaData.activeTransferId ?? ""

--- a/ui-spa/src/components/case-management/transfer-materials-v1/TransferDestinationPage.tsx
+++ b/ui-spa/src/components/case-management/transfer-materials-v1/TransferDestinationPage.tsx
@@ -118,7 +118,7 @@ const TransferDestinationPage: React.FC = () => {
     const folders = [
       {
         id: netAppPath,
-        name: `Shared Drive: ${netAppPath}`,
+        name: `Shared Drive: ${getFolderNameFromPath(netAppPath)}`,
         path: netAppPath,
         isFolder: true,
         isRootNode: true,

--- a/ui-spa/src/components/case-management/transfer-materials-v1/TransferDestinationPage.tsx
+++ b/ui-spa/src/components/case-management/transfer-materials-v1/TransferDestinationPage.tsx
@@ -36,9 +36,9 @@ const TransferDestinationPage: React.FC = () => {
     transferSource,
     sourcePaths,
     egressWorkspaceId,
+    egressWorkspaceName,
     selectedTransferAction,
     netAppPath,
-    operationName,
   } = state.appData.transferDestinationPage;
 
   const { data: netAppData, isLoading: isNetAppFolderDataLoading } = useQuery({
@@ -118,7 +118,7 @@ const TransferDestinationPage: React.FC = () => {
     const folders = [
       {
         id: netAppPath,
-        name: `Shared Drive: ${operationName}`,
+        name: `Shared Drive: ${netAppPath}`,
         path: netAppPath,
         isFolder: true,
         isRootNode: true,
@@ -129,13 +129,13 @@ const TransferDestinationPage: React.FC = () => {
     ];
 
     return folders;
-  }, [netAppPath, netAppData, operationName]);
+  }, [netAppPath, netAppData]);
 
   const initialEgressFolderData = useMemo(() => {
     const folders = [
       {
         id: "root",
-        name: `Egress: ${operationName}`,
+        name: `Egress: ${egressWorkspaceName}`,
         path: "",
         isFolder: true,
         isRootNode: true,
@@ -145,7 +145,7 @@ const TransferDestinationPage: React.FC = () => {
     ];
 
     return folders;
-  }, [operationName, egressData]);
+  }, [egressWorkspaceName, egressData]);
 
   const [transferStatus, setTransferStatus] = useState<"validating" | null>(
     null,

--- a/ui-spa/src/components/case-management/transfer-materials-v1/index.tsx
+++ b/ui-spa/src/components/case-management/transfer-materials-v1/index.tsx
@@ -133,7 +133,7 @@ const TransferMaterialsV1Page: React.FC<TransferMaterialsV1PageProps> = ({
       netAppFolderPath,
       "Shared Drive",
       netAppPath,
-      netAppPath,
+      getFolderNameFromPath(netAppPath),
     );
   }, [netAppFolderPath, netAppPath, getPathFolders]);
 

--- a/ui-spa/src/components/case-management/transfer-materials-v1/index.tsx
+++ b/ui-spa/src/components/case-management/transfer-materials-v1/index.tsx
@@ -46,6 +46,7 @@ type TransferMaterialsV1PageProps = {
   caseId: string;
   operationName: string;
   egressWorkspaceId: string;
+  egressWorkspaceName: string;
   netAppPath: string;
   activeTransferId: string;
   urn: string;
@@ -60,6 +61,7 @@ const TransferMaterialsV1Page: React.FC<TransferMaterialsV1PageProps> = ({
   caseId,
   operationName,
   egressWorkspaceId,
+  egressWorkspaceName,
   netAppPath,
   activeTransferId,
   urn,
@@ -91,7 +93,7 @@ const TransferMaterialsV1Page: React.FC<TransferMaterialsV1PageProps> = ({
       currentFolderPath: string,
       homeName: string,
       rootPath: string,
-      operationName: string,
+      homeLabel: string,
     ) => {
       const replacedString = currentFolderPath.replace(rootPath, "");
       const parts = replacedString.split("/").filter(Boolean);
@@ -102,7 +104,7 @@ const TransferMaterialsV1Page: React.FC<TransferMaterialsV1PageProps> = ({
       }));
       const withHome = [
         {
-          folderName: `${homeName}: ${operationName}`,
+          folderName: `${homeName}: ${homeLabel}`,
           folderPath: rootPath,
         },
         ...result,
@@ -119,16 +121,21 @@ const TransferMaterialsV1Page: React.FC<TransferMaterialsV1PageProps> = ({
     transferEgressFolderPathInitialValue ?? "",
   );
   const egressPathFolders = useMemo(() => {
-    return getPathFolders(egressFolderPath, "Egress", "", operationName);
-  }, [egressFolderPath, getPathFolders, operationName]);
+    return getPathFolders(
+      egressFolderPath,
+      "Egress",
+      "",
+      egressWorkspaceName,
+    );
+  }, [egressFolderPath, getPathFolders, egressWorkspaceName]);
   const netAppPathFolders = useMemo(() => {
     return getPathFolders(
       netAppFolderPath,
       "Shared Drive",
       netAppPath,
-      operationName,
+      netAppPath,
     );
-  }, [netAppFolderPath, netAppPath, getPathFolders, operationName]);
+  }, [netAppFolderPath, netAppPath, getPathFolders]);
 
   const [selectedSourceFoldersOrFiles, setSelectedSourceFoldersOrFiles] =
     useState<string[]>([]);
@@ -505,6 +512,7 @@ const TransferMaterialsV1Page: React.FC<TransferMaterialsV1PageProps> = ({
         selectedTransferAction: type,
         sourcePaths: getTransferSourcePath(),
         egressWorkspaceId,
+        egressWorkspaceName,
         netAppPath,
         operationName,
       },

--- a/ui-spa/src/mocks/data/caseMetaData.dev.ts
+++ b/ui-spa/src/mocks/data/caseMetaData.dev.ts
@@ -2,6 +2,7 @@ import { type CaseMetaDataResponse } from "../../schemas";
 export const caseMetaDataDev: CaseMetaDataResponse = {
   caseId: 12,
   egressWorkspaceId: "egress_1",
+  egressWorkspaceName: "Thunderstruck",
   netappFolderPath: "netapp/",
   operationName: "Thunderstruck",
   leadDefendantName: "John Doe",

--- a/ui-spa/src/mocks/data/caseMetaData.dev.ts
+++ b/ui-spa/src/mocks/data/caseMetaData.dev.ts
@@ -2,7 +2,7 @@ import { type CaseMetaDataResponse } from "../../schemas";
 export const caseMetaDataDev: CaseMetaDataResponse = {
   caseId: 12,
   egressWorkspaceId: "egress_1",
-  egressWorkspaceName: "Thunderstruck",
+  egressWorkspaceName: "Workspace-Alpha",
   netappFolderPath: "netapp/",
   operationName: "Thunderstruck",
   leadDefendantName: "John Doe",

--- a/ui-spa/src/mocks/data/caseMetaData.playwright.ts
+++ b/ui-spa/src/mocks/data/caseMetaData.playwright.ts
@@ -2,7 +2,7 @@ import { type CaseMetaDataResponse } from "../../schemas";
 export const caseMetaDataPlaywright: CaseMetaDataResponse = {
   caseId: 12,
   egressWorkspaceId: "egress_1",
-  egressWorkspaceName: "Thunderstruck",
+  egressWorkspaceName: "Workspace-Alpha",
   netappFolderPath: "netapp/",
   operationName: "Thunderstruck",
   leadDefendantName: null,

--- a/ui-spa/src/mocks/data/caseMetaData.playwright.ts
+++ b/ui-spa/src/mocks/data/caseMetaData.playwright.ts
@@ -2,6 +2,7 @@ import { type CaseMetaDataResponse } from "../../schemas";
 export const caseMetaDataPlaywright: CaseMetaDataResponse = {
   caseId: 12,
   egressWorkspaceId: "egress_1",
+  egressWorkspaceName: "Thunderstruck",
   netappFolderPath: "netapp/",
   operationName: "Thunderstruck",
   leadDefendantName: null,

--- a/ui-spa/src/reducers/mainStateReducer.test.ts
+++ b/ui-spa/src/reducers/mainStateReducer.test.ts
@@ -119,6 +119,7 @@ describe("mainStateReducer", () => {
     const caseMeta = {
       caseId: 1,
       egressWorkspaceId: "ew1",
+      egressWorkspaceName: "Workspace",
       netappFolderPath: "path",
       operationName: "Op",
       leadDefendantName: "John",
@@ -222,6 +223,7 @@ describe("mainStateReducer", () => {
       selectedTransferAction: null,
       sourcePaths: [],
       egressWorkspaceId: "e",
+      egressWorkspaceName: "workspace",
       netAppPath: "n",
       operationName: "op",
     } as any;

--- a/ui-spa/src/reducers/mainStateReducer.ts
+++ b/ui-spa/src/reducers/mainStateReducer.ts
@@ -26,6 +26,7 @@ type TransferDestinationPageData = {
       }[]
     | { path: string }[];
   egressWorkspaceId: string;
+  egressWorkspaceName: string;
   netAppPath: string;
   operationName: string;
 };
@@ -125,6 +126,7 @@ export const initialState: MainState = {
       selectedTransferAction: null,
       sourcePaths: [],
       egressWorkspaceId: "",
+      egressWorkspaceName: "",
       netAppPath: "",
       operationName: "",
     },

--- a/ui-spa/src/schemas/responses/caseMetaData.test.ts
+++ b/ui-spa/src/schemas/responses/caseMetaData.test.ts
@@ -5,6 +5,7 @@ describe("caseMetaDataResponseSchema", () => {
   const base = {
     caseId: 123,
     egressWorkspaceId: "egress-1",
+    egressWorkspaceName: "Workspace A",
     netappFolderPath: "\\\netapp\\folder",
     operationName: "Operation A",
     leadDefendantName: "John Doe",

--- a/ui-spa/src/schemas/responses/caseMetaData.ts
+++ b/ui-spa/src/schemas/responses/caseMetaData.ts
@@ -4,6 +4,7 @@ export const caseMetaDataResponseSchema = z
   .object({
     caseId: z.number(),
     egressWorkspaceId: z.string(),
+    egressWorkspaceName: z.string().nullable(),
     netappFolderPath: z.string(),
     operationName: z.string().nullable(),
     leadDefendantName: z.string().nullable(),


### PR DESCRIPTION
# PR checklist

Tick what applies before you raise. Delete anything that doesn't.

## Correctness
- [x] Does what the ticket asks for
- [x] Handles the edge cases (empty, null, zero, large inputs), not just the happy path
- [x] Errors are handled, not swallowed
- [x] New logic has tests, including the failure cases
- [x] Tests assert something real, not just run the code

## Keeping it simple
- [x] Doesn't rebuild something that already exists in the codebase
- [x] No more complex or slower than it needs to be
- [x] No leftover debug logging or commented-out code

## Easy to miss (a green pipeline won't flag these)
- [x] One logical change, not a pile of unrelated stuff

### If you touched the backend
- [x] Schema changes have a migration, and the Down() doesn't drop anything it shouldn't
- [x] New app settings are wired into the fa-config templates
- [x] Secrets use Key Vault references, not plain text
- [x] New outbound HTTP clients go through the shared resilience handler (AddResiliencePolicyHandler), rather than hand-rolling retries
- [x] New calls to an external service (DDEI, Egress, NetApp) have client tests against a WireMock stub (for the serialisation, auth and error handling) and are covered by the integration tests that run against the real dev services
- [x] Ran dotnet format, since CI builds and tests but doesn't check formatting

### If you touched the UI
- [x] Ran the e2e/ suite locally (the PR build only runs the mocked tests; the full suite runs post-merge and gates the deploy)
- [x] API changes are reflected in the MSW handlers in src/mocks and the matching zod schema, so the mocked tests aren't passing against a contract that's gone
- [x] New config or feature flags are wired into the VITE build variables, not just added in code
- [x] Data fetches handle the loading, empty and error states, not just success, and match how the rest of the app already does it
- [x] Ran prettier (npm run prettier:format), since CI lints but doesn't check formatting
- [x] Checked accessibility (keyboard nav, screen reader, sensible labels), since the Lighthouse run is manual and won't flag it for you