### PR TITLE
fix: increase polling grace period to prevent false transfer errors (FCT2-20905)

### DIFF
--- a/ui-spa/src/common/utils/pollTransferStatus.test.ts
+++ b/ui-spa/src/common/utils/pollTransferStatus.test.ts
@@ -254,9 +254,9 @@ describe("pollTransferStatus", async () => {
       100,
     );
 
-    // The grace window is 30s of wall-clock. Just before it elapses the loop is
+    // The grace window is 90s of wall-clock. Just before it elapses the loop is
     // still polling and has not surfaced an error.
-    await vi.advanceTimersByTimeAsync(29900);
+    await vi.advanceTimersByTimeAsync(89900);
     expect(handleResponse).to.toHaveBeenCalledTimes(0);
     expect(handleError).to.toHaveBeenCalledTimes(0);
     expect(getTransferStatus).to.toHaveBeenCalled();
@@ -270,7 +270,7 @@ describe("pollTransferStatus", async () => {
 
     // The loop has given up: no further polling and no further errors.
     const callsAfterStop = (getTransferStatus as Mock).mock.calls.length;
-    await vi.advanceTimersByTimeAsync(30000);
+    await vi.advanceTimersByTimeAsync(90000);
     expect(getTransferStatus).to.toHaveBeenCalledTimes(callsAfterStop);
     expect(handleError).to.toHaveBeenCalledTimes(1);
   });

--- a/ui-spa/src/common/utils/pollTransferStatus.ts
+++ b/ui-spa/src/common/utils/pollTransferStatus.ts
@@ -14,7 +14,7 @@ const MID_INTERVAL_MS = 3000;
  * instead of polling forever (e.g. an orchestration that failed before the
  * entity was created, or a stale/incorrect transfer ID).
  */
-const NOT_FOUND_GRACE_MS = 30000;
+const NOT_FOUND_GRACE_MS = 90000; // 90s
 
 /**
  * Polls the transfer status endpoint with adaptive backoff until a terminal state is reached


### PR DESCRIPTION
# PR checklist

## Correctness
- [x] Does what the ticket asks for

## Keeping it simple
- [x] Doesn't rebuild something that already exists in the codebase
- [x] No more complex or slower than it needs to be
- [x] No leftover debug logging or commented-out code

## Easy to miss (a green pipeline won't flag these)
- [x] One logical change, not a pile of unrelated stuff

When a transfer is initiated, the API returns `202 Accepted` immediately but the Durable Entity that tracks transfer status is only created once the orchestrator starts running. On cold starts, the orchestrator can take longer than 30 seconds to spin up.

The UI polls for transfer status and previously had a 30-second grace window for `404` responses before surfacing an error. This caused users to see "Transfer not found" errors even though the transfer completed successfully in the background.
