### PR TITLE
FCT2-21135- removed the featuregroup2 restriction for disconnectSharedDrive and transferMaterialV1 features

### DIFF
--- a/ui-spa/src/common/hooks/useUserGroupsFeatureFlag.test.tsx
+++ b/ui-spa/src/common/hooks/useUserGroupsFeatureFlag.test.tsx
@@ -31,6 +31,7 @@ const mockConfig = configModule as {
   FEATURE_FLAG_DISCONNECT_SHARED_DRIVE: boolean;
   PRIVATE_BETA_FEATURE_USER_GROUP2: string;
   FEATURE_FLAG_MAINTENANCE_MODE: boolean;
+  FEATURE_FLAG_TRANSFER_MATERIALS_V1: boolean;
 };
 
 describe("useUserGroupsFeatureFlag", () => {
@@ -348,19 +349,18 @@ describe("useUserGroupsFeatureFlag", () => {
   });
 
   describe("disconnect shared drive flag", () => {
-    test("Should return disconnectSharedDrive feature false, if FEATURE_FLAG_DISCONNECT_SHARED_DRIVE is false for normal user", () => {
+    test("Should return disconnectSharedDrive feature false, if FEATURE_FLAG_DISCONNECT_SHARED_DRIVE is false for normal user and there is no token group restriction", () => {
       (msalInstanceModule.msalInstance.getAllAccounts as Mock).mockReturnValue([
         {
           username: "test_username",
           name: "test_name",
           idTokenClaims: {
-            groups: ["private_beta_feature_group2"],
+            groups: [],
           },
         },
       ]);
       mockConfig.FEATURE_FLAG_DISCONNECT_SHARED_DRIVE = false;
-      mockConfig.PRIVATE_BETA_FEATURE_USER_GROUP2 =
-        "private_beta_feature_group2";
+
       const { result } = renderHook(() => useUserGroupsFeatureFlag());
       expect(result?.current?.disconnectSharedDrive).toStrictEqual(false);
     });
@@ -373,49 +373,17 @@ describe("useUserGroupsFeatureFlag", () => {
           username: "dev_user@example.org",
           name: "dev_user",
           idTokenClaims: {
-            groups: ["private_beta_feature_group2"],
+            groups: [],
           },
         },
       ]);
       mockConfig.FEATURE_FLAG_DISCONNECT_SHARED_DRIVE = false;
-      mockConfig.PRIVATE_BETA_FEATURE_USER_GROUP2 =
-        "private_beta_feature_group2";
+
       const { result } = renderHook(() => useUserGroupsFeatureFlag());
       expect(result?.current?.disconnectSharedDrive).toStrictEqual(false);
     });
-    test("Should return disconnectSharedDrive feature false, if FEATURE_FLAG_DISCONNECT_SHARED_DRIVE is true and the user is not added to PRIVATE_BETA_FEATURE_USER_GROUP2 for normal user", () => {
-      (msalInstanceModule.msalInstance.getAllAccounts as Mock).mockReturnValue([
-        {
-          username: "test_username",
-          name: "test_name",
-          idTokenClaims: {
-            groups: ["private_beta_feature_group1"],
-          },
-        },
-      ]);
-      mockConfig.FEATURE_FLAG_DISCONNECT_SHARED_DRIVE = true;
-      mockConfig.PRIVATE_BETA_FEATURE_USER_GROUP2 =
-        "private_beta_feature_group2";
-      const { result } = renderHook(() => useUserGroupsFeatureFlag());
-      expect(result?.current?.disconnectSharedDrive).toStrictEqual(false);
-    });
-    test("Should return disconnectSharedDrive feature true, if FEATURE_FLAG_DISCONNECT_SHARED_DRIVE is true and the user is added to PRIVATE_BETA_FEATURE_USER_GROUP2 for normal user", () => {
-      (msalInstanceModule.msalInstance.getAllAccounts as Mock).mockReturnValue([
-        {
-          username: "test_username",
-          name: "test_name",
-          idTokenClaims: {
-            groups: ["private_beta_feature_group2"],
-          },
-        },
-      ]);
-      mockConfig.FEATURE_FLAG_DISCONNECT_SHARED_DRIVE = true;
-      mockConfig.PRIVATE_BETA_FEATURE_USER_GROUP2 =
-        "private_beta_feature_group2";
-      const { result } = renderHook(() => useUserGroupsFeatureFlag());
-      expect(result?.current?.disconnectSharedDrive).toStrictEqual(true);
-    });
-    test("Should return disconnectSharedDrive feature true, if FEATURE_FLAG_DISCONNECT_SHARED_DRIVE is true even if the user is not added to PRIVATE_BETA_FEATURE_USER_GROUP2 for automation user", () => {
+
+    test("Should return disconnectSharedDrive feature true, if FEATURE_FLAG_DISCONNECT_SHARED_DRIVE is true for automation user", () => {
       (auth.useUserDetails as Mock).mockReturnValue({
         username: "dev_user@example.org",
       });
@@ -429,8 +397,7 @@ describe("useUserGroupsFeatureFlag", () => {
         },
       ]);
       mockConfig.FEATURE_FLAG_DISCONNECT_SHARED_DRIVE = true;
-      mockConfig.PRIVATE_BETA_FEATURE_USER_GROUP2 =
-        "private_beta_feature_group2";
+
       const { result } = renderHook(() => useUserGroupsFeatureFlag());
       expect(result?.current?.disconnectSharedDrive).toStrictEqual(true);
     });
@@ -453,8 +420,6 @@ describe("useUserGroupsFeatureFlag", () => {
         },
       ]);
       mockConfig.FEATURE_FLAG_DISCONNECT_SHARED_DRIVE = false;
-      mockConfig.PRIVATE_BETA_FEATURE_USER_GROUP2 =
-        "private_beta_feature_group2";
       const { result } = renderHook(() => useUserGroupsFeatureFlag());
       expect(result?.current?.disconnectSharedDrive).toStrictEqual(true);
     });
@@ -477,20 +442,115 @@ describe("useUserGroupsFeatureFlag", () => {
         },
       ]);
       mockConfig.FEATURE_FLAG_DISCONNECT_SHARED_DRIVE = true;
-      mockConfig.PRIVATE_BETA_FEATURE_USER_GROUP2 =
-        "private_beta_feature_group2";
       const { result } = renderHook(() => useUserGroupsFeatureFlag());
       expect(result?.current?.disconnectSharedDrive).toStrictEqual(false);
     });
   });
 
-   describe("maintenance mode feature flag", () => {
+  describe("transferMaterialsV1 flag", () => {
+    test("Should return transferMaterialsV1 feature false, if FEATURE_FLAG_TRANSFER_MATERIALS_V1 is false for normal user, and there is no token group restriction", () => {
+      (msalInstanceModule.msalInstance.getAllAccounts as Mock).mockReturnValue([
+        {
+          username: "test_username",
+          name: "test_name",
+          idTokenClaims: {
+            groups: [],
+          },
+        },
+      ]);
+      mockConfig.FEATURE_FLAG_TRANSFER_MATERIALS_V1 = false;
+
+      const { result } = renderHook(() => useUserGroupsFeatureFlag());
+      expect(result?.current?.transferMaterialsV1).toStrictEqual(false);
+    });
+    test("Should return transferMaterialsV1 feature false, if FEATURE_FLAG_TRANSFER_MATERIALS_V1 is false for automation test user ", () => {
+      (auth.useUserDetails as Mock).mockReturnValue({
+        username: "dev_user@example.org",
+      });
+      (msalInstanceModule.msalInstance.getAllAccounts as Mock).mockReturnValue([
+        {
+          username: "dev_user@example.org",
+          name: "dev_user",
+          idTokenClaims: {
+            groups: [],
+          },
+        },
+      ]);
+      mockConfig.FEATURE_FLAG_TRANSFER_MATERIALS_V1 = false;
+
+      const { result } = renderHook(() => useUserGroupsFeatureFlag());
+      expect(result?.current?.transferMaterialsV1).toStrictEqual(false);
+    });
+    test("Should return transferMaterialsV1 feature true, if FEATURE_FLAG_TRANSFER_MATERIALS_V1 is true for automation user", () => {
+      (auth.useUserDetails as Mock).mockReturnValue({
+        username: "dev_user@example.org",
+      });
+      (msalInstanceModule.msalInstance.getAllAccounts as Mock).mockReturnValue([
+        {
+          username: "test_username",
+          name: "test_name",
+          idTokenClaims: {
+            groups: ["private_beta_feature_group1"],
+          },
+        },
+      ]);
+      mockConfig.FEATURE_FLAG_TRANSFER_MATERIALS_V1 = true;
+      const { result } = renderHook(() => useUserGroupsFeatureFlag());
+      expect(result?.current?.transferMaterialsV1).toStrictEqual(true);
+    });
+    test("Should return transferMaterialsV1 feature true, if it is an automation user with search param transfer-materials-v1=true, search param take priority for automation user", () => {
+      (auth.useUserDetails as Mock).mockReturnValue({
+        username: "dev_user@example.org",
+      });
+      (router.useSearchParams as Mock).mockReturnValue([
+        new URLSearchParams("transfer-materials-v1=true"),
+        vi.fn(),
+      ]);
+
+      (msalInstanceModule.msalInstance.getAllAccounts as Mock).mockReturnValue([
+        {
+          username: "test_username",
+          name: "test_name",
+          idTokenClaims: {
+            groups: [],
+          },
+        },
+      ]);
+      mockConfig.FEATURE_FLAG_TRANSFER_MATERIALS_V1 = false;
+
+      const { result } = renderHook(() => useUserGroupsFeatureFlag());
+      expect(result?.current?.transferMaterialsV1).toStrictEqual(true);
+    });
+    test("Should return transferMaterialsV1 feature false, if it is an automation user with search param transfer-materials-v1=false,search param take priority for automation user", () => {
+      (auth.useUserDetails as Mock).mockReturnValue({
+        username: "dev_user@example.org",
+      });
+      (router.useSearchParams as Mock).mockReturnValue([
+        new URLSearchParams("transfer-materials-v1=false"),
+        vi.fn(),
+      ]);
+
+      (msalInstanceModule.msalInstance.getAllAccounts as Mock).mockReturnValue([
+        {
+          username: "test_username",
+          name: "test_name",
+          idTokenClaims: {
+            groups: [],
+          },
+        },
+      ]);
+      mockConfig.FEATURE_FLAG_TRANSFER_MATERIALS_V1 = true;
+      const { result } = renderHook(() => useUserGroupsFeatureFlag());
+      expect(result?.current?.transferMaterialsV1).toStrictEqual(false);
+    });
+  });
+
+  describe("maintenance mode feature flag", () => {
     test("Should return maintenanceMode feature false, if FEATURE_FLAG_MAINTENANCE_MODE is false for normal user", () => {
       (msalInstanceModule.msalInstance.getAllAccounts as Mock).mockReturnValue([
         {
           username: "test_username",
           name: "test_name",
-         
         },
       ]);
       mockConfig.FEATURE_FLAG_MAINTENANCE_MODE = false;
@@ -506,7 +566,6 @@ describe("useUserGroupsFeatureFlag", () => {
         {
           username: "dev_user@example.org",
           name: "dev_user",
-         
         },
       ]);
       mockConfig.FEATURE_FLAG_MAINTENANCE_MODE = false;
@@ -522,16 +581,15 @@ describe("useUserGroupsFeatureFlag", () => {
         new URLSearchParams("maintenance-mode=true"),
         vi.fn(),
       ]);
-        (msalInstanceModule.msalInstance.getAllAccounts as Mock).mockReturnValue([
+      (msalInstanceModule.msalInstance.getAllAccounts as Mock).mockReturnValue([
         {
           username: "dev_user@example.org",
           name: "dev_user",
-         
         },
       ]);
 
       mockConfig.FEATURE_FLAG_MAINTENANCE_MODE = false;
-     
+
       const { result } = renderHook(() => useUserGroupsFeatureFlag());
       expect(result?.current?.maintenanceMode).toStrictEqual(true);
     });
@@ -548,11 +606,10 @@ describe("useUserGroupsFeatureFlag", () => {
         {
           username: "dev_user@example.org",
           name: "dev_user",
-         
         },
       ]);
       mockConfig.FEATURE_FLAG_MAINTENANCE_MODE = true;
-     
+
       const { result } = renderHook(() => useUserGroupsFeatureFlag());
       expect(result?.current?.maintenanceMode).toStrictEqual(false);
     });

--- a/ui-spa/src/common/hooks/useUserGroupsFeatureFlag.ts
+++ b/ui-spa/src/common/hooks/useUserGroupsFeatureFlag.ts
@@ -83,19 +83,11 @@ export const useUserGroupsFeatureFlag = (): FeatureFlagData | null => {
         userDetails.username,
         FEATURE_FLAG_DISCONNECT_SHARED_DRIVE,
         searchParams?.get("disconnect-shared-drive"),
-        {
-          groups: groups,
-          groupKey: PRIVATE_BETA_FEATURE_USER_GROUP2,
-        },
       ),
       transferMaterialsV1: shouldShowFeature(
         userDetails.username,
         FEATURE_FLAG_TRANSFER_MATERIALS_V1,
         searchParams?.get("transfer-materials-v1"),
-        {
-          groups: groups,
-          groupKey: PRIVATE_BETA_FEATURE_USER_GROUP2,
-        },
       ),
       maintenanceMode: shouldShowFeature(
         userDetails.username,


### PR DESCRIPTION


# PR checklist

Tick what applies before you raise. Delete anything that doesn't.

## Correctness
- [x] Does what the ticket asks for
- [x] Handles the edge cases (empty, null, zero, large inputs), not just the happy path
- [x] Errors are handled, not swallowed
- [x] New logic has tests, including the failure cases
- [x] Tests assert something real, not just run the code

## Keeping it simple
- [x] Doesn't rebuild something that already exists in the codebase
- [x] No more complex or slower than it needs to be
- [x] No leftover debug logging or commented-out code

## Easy to miss (a green pipeline won't flag these)
- [ ] One logical change, not a pile of unrelated stuff

### If you touched the UI
- [x] API changes are reflected in the MSW handlers in src/mocks and the matching zod schema, so the mocked tests aren't passing against a contract that's gone
- [x] New config or feature flags are wired into the VITE build variables, not just added in code
- [x] Data fetches handle the loading, empty and error states, not just success, and match how the rest of the app already does it
- [x] Ran prettier (npm run prettier:format), since CI lints but doesn't check formatting
- [ ] Checked accessibility (keyboard nav, screen reader, sensible labels), since the Lighthouse run is manual and won't flag it for you