### PR TITLE
disable egress source folder cleanup for debugging

### DIFF
--- a/devops-pipelines/move-soak-test.yml
+++ b/devops-pipelines/move-soak-test.yml
@@ -120,14 +120,15 @@ jobs:
             -ExcludePatterns "lcc-e2e-fixture-source"
             -Force
 
-      - task: PowerShell@2
-        displayName: "Clear ExistingCaseAutomation Egress folder"
-        condition: succeededOrFailed()
-        inputs:
-          filePath: "$(System.DefaultWorkingDirectory)/devops-pipelines/scripts/test-automation-cleanup/Clear-EgressFolder.ps1"
-          arguments: >
-            -BaseUrl "$(EgressOptionsUrl)"
-            -ServiceAccountAuth "$(EgressServiceAccountAuth)"
-            -WorkspaceId "$(E2eEgressWorkspaceId)"
-            -FolderName "1. ABEs for Transcript"
-            -Force
+      # # Egress cleanup disabled to investigate failed post-move delete from source
+      # - task: PowerShell@2
+      #   displayName: "Clear ExistingCaseAutomation Egress folder"
+      #   condition: succeededOrFailed()
+      #   inputs:
+      #     filePath: "$(System.DefaultWorkingDirectory)/devops-pipelines/scripts/test-automation-cleanup/Clear-EgressFolder.ps1"
+      #     arguments: >
+      #       -BaseUrl "$(EgressOptionsUrl)"
+      #       -ServiceAccountAuth "$(EgressServiceAccountAuth)"
+      #       -WorkspaceId "$(E2eEgressWorkspaceId)"
+      #       -FolderName "1. ABEs for Transcript"
+      #       -Force


### PR DESCRIPTION
To investigate if files are indeed failing to be deleted from Egress after move and eliminate the possibility that it's a timing issue with the test itself - I disabled the clean up jobs that removes any files in the egress source folder.