### PR TITLE
Feature/fct2 21384 selectable bucket

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-json
       - id: pretty-format-json
         args: [
-          --auto-fix,
+          --autofix,
           --no-sort-keys
         ]
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -71,7 +71,7 @@
       "label": "run-backend-file-transfer",
       "type": "shell",
       "options": {
-        "cwd": "${workspaceFolder}/backend/CPS.ComplexCases.FileTransfer.API/bin/Debug/net10.0",
+        "cwd": "${workspaceFolder}/backend/CPS.ComplexCases.FileTransfer.API/bin/Debug/net10.0"
       },
       "command": "func start --no-build --verbose --password CPS.ComplexCases.FileTransfer.API",
       "isBackground": true,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "run-azurite",
       "type": "shell",
-      "command": "azurite --inMemoryPersistence",
+      "command": "azurite --inMemoryPersistence --skipApiVersionCheck",
       "options": {
         "cwd": "${workspaceFolder}/.vscode"
       },
@@ -58,7 +58,7 @@
       "label": "run-backend",
       "type": "shell",
       "options": {
-        "cwd": "${workspaceFolder}/backend/CPS.ComplexCases.API/bin/Debug/net8.0",
+        "cwd": "${workspaceFolder}/backend/CPS.ComplexCases.API/bin/Debug/net10.0",
         "env": {
           "DDEIOptions__MockBaseUrl": "http://localhost:7081"
         }
@@ -71,7 +71,7 @@
       "label": "run-backend-file-transfer",
       "type": "shell",
       "options": {
-        "cwd": "${workspaceFolder}/backend/CPS.ComplexCases.FileTransfer.API/bin/Debug/net8.0",
+        "cwd": "${workspaceFolder}/backend/CPS.ComplexCases.FileTransfer.API/bin/Debug/net10.0",
       },
       "command": "func start --no-build --verbose --password CPS.ComplexCases.FileTransfer.API",
       "isBackground": true,
@@ -138,7 +138,7 @@
       "options": {
         "cwd": "${workspaceFolder}/backend/CPS.ComplexCases.WireMock"
       },
-      "command": "dotnet bin/Debug/net8.0/CPS.ComplexCases.WireMock.dll",
+      "command": "dotnet bin/Debug/net10.0/CPS.ComplexCases.WireMock.dll",
       "isBackground": true,
       "problemMatcher": {
         "fileLocation": "absolute",
@@ -274,7 +274,7 @@
       "type": "func",
       "dependsOn": "build (functions)",
       "options": {
-        "cwd": "${workspaceFolder}/backend\\CPS.ComplexCases.FileTransfer.API/bin/Debug/net8.0"
+        "cwd": "${workspaceFolder}/backend\\CPS.ComplexCases.FileTransfer.API/bin/Debug/net10.0"
       },
       "command": "host start",
       "isBackground": true,

--- a/backend/CPS.ComplexCases.API.Tests/Unit/Functions/CreateNetAppFolderTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Functions/CreateNetAppFolderTests.cs
@@ -11,6 +11,8 @@ using CPS.ComplexCases.API.Validators.Requests;
 using CPS.ComplexCases.Common.Handlers;
 using CPS.ComplexCases.Common.Helpers;
 using CPS.ComplexCases.Common.Models;
+using CPS.ComplexCases.Common.Services;
+using CPS.ComplexCases.Data.Entities;
 using CPS.ComplexCases.NetApp.Client;
 using CPS.ComplexCases.NetApp.Factories;
 using CPS.ComplexCases.NetApp.Models.Args;
@@ -30,7 +32,8 @@ public class CreateNetAppFolderTests
     private readonly Mock<INetAppArgFactory> _netAppArgFactoryMock;
     private readonly Mock<IActivityLogService> _activityLogServiceMock;
     private readonly Mock<IRequestValidator> _requestValidatorMock;
-    private readonly Mock<ISecurityGroupMetadataService> _securityGroupMetadataServiceMock;
+    private readonly Mock<IUserBucketAccessService> _userBucketAccessServiceMock;
+    private readonly Mock<ICaseMetadataService> _caseMetadataServiceMock;
     private readonly Mock<IInitializationHandler> _initializationHandlerMock;
     private readonly CreateNetAppFolder _function;
     private readonly Fixture _fixture;
@@ -48,7 +51,8 @@ public class CreateNetAppFolderTests
         _netAppArgFactoryMock = new Mock<INetAppArgFactory>();
         _activityLogServiceMock = new Mock<IActivityLogService>();
         _requestValidatorMock = new Mock<IRequestValidator>();
-        _securityGroupMetadataServiceMock = new Mock<ISecurityGroupMetadataService>();
+        _userBucketAccessServiceMock = new Mock<IUserBucketAccessService>();
+        _caseMetadataServiceMock = new Mock<ICaseMetadataService>();
         _initializationHandlerMock = new Mock<IInitializationHandler>();
 
         _fixture = new Fixture();
@@ -74,7 +78,8 @@ public class CreateNetAppFolderTests
             _netAppArgFactoryMock.Object,
             _activityLogServiceMock.Object,
             _requestValidatorMock.Object,
-            _securityGroupMetadataServiceMock.Object,
+            _userBucketAccessServiceMock.Object,
+            _caseMetadataServiceMock.Object,
             _initializationHandlerMock.Object);
     }
 
@@ -133,7 +138,7 @@ public class CreateNetAppFolderTests
         Assert.Equal(validationErrors, errors);
 
         _initializationHandlerMock.Verify(h => h.Initialize(_testUsername, _testCorrelationId, null), Times.Once);
-        _securityGroupMetadataServiceMock.Verify(s => s.GetUserSecurityGroupsAsync(It.IsAny<string>()), Times.Never);
+        _userBucketAccessServiceMock.Verify(s => s.ResolveBucketAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
         _netAppClientMock.Verify(c => c.ListFoldersInBucketAsync(It.IsAny<ListFoldersInBucketArg>()), Times.Never);
         _netAppClientMock.Verify(c => c.CreateFolderAsync(It.IsAny<CreateFolderArg>()), Times.Never);
     }
@@ -150,9 +155,9 @@ public class CreateNetAppFolderTests
         var dto = new CreateNetAppFolderDto { Path = folderPath, CaseId = 42 };
         SetupValidRequest(dto);
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(_testBearerToken))
-            .ReturnsAsync(_defaultSecurityGroups);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(_defaultSecurityGroups[0]);
 
         var parentPath = folderPath.Contains('/') ? folderPath[..folderPath.LastIndexOf('/')] : string.Empty;
         var listFoldersArg = _fixture.Create<ListFoldersInBucketArg>();
@@ -197,9 +202,9 @@ public class CreateNetAppFolderTests
         var dto = new CreateNetAppFolderDto { Path = folderPath, CaseId = 42 };
         SetupValidRequest(dto);
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(_testBearerToken))
-            .ReturnsAsync(_defaultSecurityGroups);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(_defaultSecurityGroups[0]);
 
         SetupNoExistingFolders(folderPath);
 
@@ -236,9 +241,9 @@ public class CreateNetAppFolderTests
         var dto = new CreateNetAppFolderDto { Path = folderPath, CaseId = caseId };
         SetupValidRequest(dto);
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(_testBearerToken))
-            .ReturnsAsync(_defaultSecurityGroups);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(_defaultSecurityGroups[0]);
 
         SetupNoExistingFolders(folderPath);
 
@@ -262,7 +267,7 @@ public class CreateNetAppFolderTests
         Assert.True((bool)okResult.Value!);
 
         _initializationHandlerMock.Verify(h => h.Initialize(_testUsername, _testCorrelationId, null), Times.Once);
-        _securityGroupMetadataServiceMock.Verify(s => s.GetUserSecurityGroupsAsync(_testBearerToken), Times.Once);
+        _userBucketAccessServiceMock.Verify(s => s.ResolveBucketAsync(_testBearerToken, It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
         _netAppArgFactoryMock.Verify(f => f.CreateCreateFolderArg(_testBearerToken, _testBucketName, folderPath), Times.Once);
         _netAppClientMock.Verify(c => c.CreateFolderAsync(createArg), Times.Once);
     }
@@ -277,9 +282,9 @@ public class CreateNetAppFolderTests
         var dto = new CreateNetAppFolderDto { Path = folderPath, CaseId = caseId };
         SetupValidRequest(dto);
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(_testBearerToken))
-            .ReturnsAsync(_defaultSecurityGroups);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(_defaultSecurityGroups[0]);
 
         SetupNoExistingFolders(folderPath);
 
@@ -320,9 +325,9 @@ public class CreateNetAppFolderTests
         var dto = new CreateNetAppFolderDto { Path = folderPath, CaseId = caseId };
         SetupValidRequest(dto);
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(_testBearerToken))
-            .ReturnsAsync(_defaultSecurityGroups);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(_defaultSecurityGroups[0]);
 
         SetupNoExistingFolders(folderPath);
 
@@ -366,9 +371,9 @@ public class CreateNetAppFolderTests
         var dto = new CreateNetAppFolderDto { Path = folderPath, CaseId = 1 };
         SetupValidRequest(dto);
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(_testBearerToken))
-            .ReturnsAsync(_defaultSecurityGroups);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(_defaultSecurityGroups[0]);
 
         SetupNoExistingFolders(folderPath);
 
@@ -405,9 +410,9 @@ public class CreateNetAppFolderTests
         var dto = new CreateNetAppFolderDto { Path = folderPath, CaseId = caseId };
         SetupValidRequest(dto);
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(_testBearerToken))
-            .ReturnsAsync(_defaultSecurityGroups);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(_defaultSecurityGroups[0]);
 
         SetupNoExistingFolders(folderPath);
 
@@ -447,9 +452,9 @@ public class CreateNetAppFolderTests
         var dto = new CreateNetAppFolderDto { Path = folderPathWithSlash, CaseId = 5 };
         SetupValidRequest(dto);
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(_testBearerToken))
-            .ReturnsAsync(_defaultSecurityGroups);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(_defaultSecurityGroups[0]);
 
         SetupNoExistingFolders(normalised);
 
@@ -488,8 +493,8 @@ public class CreateNetAppFolderTests
         var dto = new CreateNetAppFolderDto { Path = "op/folder", CaseId = 1 };
         SetupValidRequest(dto);
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(_testBearerToken))
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, It.IsAny<string?>(), It.IsAny<string?>()))
             .ThrowsAsync(new MissingSecurityGroupException("No matching security groups found for the provided IDs."));
 
         var httpRequest = HttpRequestStubHelper.CreateHttpRequestFor(dto);
@@ -500,46 +505,36 @@ public class CreateNetAppFolderTests
             _function.Run(httpRequest, functionContext));
 
         _initializationHandlerMock.Verify(h => h.Initialize(_testUsername, _testCorrelationId, null), Times.Once);
-        _securityGroupMetadataServiceMock.Verify(s => s.GetUserSecurityGroupsAsync(_testBearerToken), Times.Once);
+        _userBucketAccessServiceMock.Verify(s => s.ResolveBucketAsync(_testBearerToken, It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
         _netAppClientMock.Verify(c => c.ListFoldersInBucketAsync(It.IsAny<ListFoldersInBucketArg>()), Times.Never);
         _netAppClientMock.Verify(c => c.CreateFolderAsync(It.IsAny<CreateFolderArg>()), Times.Never);
     }
 
     [Fact]
-    public async Task Run_UsesFirstSecurityGroupBucketName()
+    public async Task Run_WhenCaseHasNoPersistedBucket_FallsBackToResolvedBucket()
     {
-        // Arrange
-        var firstBucketName = "first-bucket";
-        var secondBucketName = "second-bucket";
+        // Arrange — covers cases connected before the bucket was persisted on CaseMetadata
+        var fallbackBucketName = "first-bucket";
         var folderPath = "operation-123/my-folder";
-        var dto = new CreateNetAppFolderDto { Path = folderPath, CaseId = 1 };
+        var caseId = 1;
+        var dto = new CreateNetAppFolderDto { Path = folderPath, CaseId = caseId };
         SetupValidRequest(dto);
 
-        var securityGroups = new List<SecurityGroup>
-        {
-            new() { Id = _fixture.Create<Guid>(), BucketName = firstBucketName, VolumeUuid = _fixture.Create<Guid>(), DisplayName = "First" },
-            new() { Id = _fixture.Create<Guid>(), BucketName = secondBucketName, VolumeUuid = _fixture.Create<Guid>(), DisplayName = "Second" }
-        };
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(_testBearerToken))
-            .ReturnsAsync(securityGroups);
+        _caseMetadataServiceMock
+            .Setup(s => s.GetCaseMetadataForCaseIdAsync(caseId))
+            .ReturnsAsync(new CaseMetadata { CaseId = caseId, NetappBucketName = null });
 
-        var parentPath = folderPath.Contains('/') ? folderPath[..folderPath.LastIndexOf('/')] : string.Empty;
-        var listFoldersArg = _fixture.Create<ListFoldersInBucketArg>();
-        _netAppArgFactoryMock
-            .Setup(f => f.CreateListFoldersInBucketArg(_testBearerToken, firstBucketName, null, null, null, parentPath))
-            .Returns(listFoldersArg);
-        _netAppClientMock
-            .Setup(c => c.ListFoldersInBucketAsync(listFoldersArg))
-            .ReturnsAsync((ListNetAppObjectsDto?)null);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, null, null))
+            .ReturnsAsync(new SecurityGroup
+            {
+                Id = _fixture.Create<Guid>(),
+                BucketName = fallbackBucketName,
+                VolumeUuid = _fixture.Create<Guid>(),
+                DisplayName = "First"
+            });
 
-        var createArg = _fixture.Create<CreateFolderArg>();
-        _netAppArgFactoryMock
-            .Setup(f => f.CreateCreateFolderArg(_testBearerToken, firstBucketName, folderPath))
-            .Returns(createArg);
-        _netAppClientMock
-            .Setup(c => c.CreateFolderAsync(createArg))
-            .ReturnsAsync(true);
+        ArrangeFolderCreation(folderPath, fallbackBucketName);
 
         var httpRequest = HttpRequestStubHelper.CreateHttpRequestFor(dto);
         var functionContext = FunctionContextStubHelper.CreateFunctionContextStub(_testCorrelationId, _testCmsAuthValues, _testUsername, _testBearerToken);
@@ -548,7 +543,64 @@ public class CreateNetAppFolderTests
         await _function.Run(httpRequest, functionContext);
 
         // Assert
-        _netAppArgFactoryMock.Verify(f => f.CreateCreateFolderArg(_testBearerToken, firstBucketName, folderPath), Times.Once);
-        _netAppArgFactoryMock.Verify(f => f.CreateCreateFolderArg(It.IsAny<string>(), secondBucketName, It.IsAny<string>()), Times.Never);
+        _userBucketAccessServiceMock.Verify(s => s.ResolveBucketAsync(_testBearerToken, null, null), Times.Once);
+        _netAppArgFactoryMock.Verify(f => f.CreateCreateFolderArg(_testBearerToken, fallbackBucketName, folderPath), Times.Once);
+    }
+
+    [Fact]
+    public async Task Run_WhenCaseHasPersistedBucket_UsesPersistedBucket()
+    {
+        // Arrange
+        var persistedBucketName = "manchester-bucket";
+        var folderPath = "operation-123/my-folder";
+        var caseId = 1;
+        var dto = new CreateNetAppFolderDto { Path = folderPath, CaseId = caseId };
+        SetupValidRequest(dto);
+
+        _caseMetadataServiceMock
+            .Setup(s => s.GetCaseMetadataForCaseIdAsync(caseId))
+            .ReturnsAsync(new CaseMetadata { CaseId = caseId, NetappBucketName = persistedBucketName });
+
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, persistedBucketName, null))
+            .ReturnsAsync(new SecurityGroup
+            {
+                Id = _fixture.Create<Guid>(),
+                BucketName = persistedBucketName,
+                VolumeUuid = _fixture.Create<Guid>(),
+                DisplayName = "Manchester"
+            });
+
+        ArrangeFolderCreation(folderPath, persistedBucketName);
+
+        var httpRequest = HttpRequestStubHelper.CreateHttpRequestFor(dto);
+        var functionContext = FunctionContextStubHelper.CreateFunctionContextStub(_testCorrelationId, _testCmsAuthValues, _testUsername, _testBearerToken);
+
+        // Act
+        await _function.Run(httpRequest, functionContext);
+
+        // Assert
+        _userBucketAccessServiceMock.Verify(s => s.ResolveBucketAsync(_testBearerToken, persistedBucketName, null), Times.Once);
+        _netAppArgFactoryMock.Verify(f => f.CreateCreateFolderArg(_testBearerToken, persistedBucketName, folderPath), Times.Once);
+    }
+
+    private void ArrangeFolderCreation(string folderPath, string bucketName)
+    {
+        var parentPath = folderPath.Contains('/') ? folderPath[..folderPath.LastIndexOf('/')] : string.Empty;
+        var listFoldersArg = _fixture.Create<ListFoldersInBucketArg>();
+        _netAppArgFactoryMock
+            .Setup(f => f.CreateListFoldersInBucketArg(_testBearerToken, bucketName, null, null, null, parentPath))
+            .Returns(listFoldersArg);
+        _netAppClientMock
+            .Setup(c => c.ListFoldersInBucketAsync(listFoldersArg))
+            .ReturnsAsync((ListNetAppObjectsDto?)null);
+
+        var createArg = _fixture.Create<CreateFolderArg>();
+        _netAppArgFactoryMock
+            .Setup(f => f.CreateCreateFolderArg(_testBearerToken, bucketName, folderPath))
+            .Returns(createArg);
+        _netAppClientMock
+            .Setup(c => c.CreateFolderAsync(createArg))
+            .ReturnsAsync(true);
     }
 }

--- a/backend/CPS.ComplexCases.API.Tests/Unit/Functions/CreateNetappConnectionTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Functions/CreateNetappConnectionTests.cs
@@ -1,6 +1,7 @@
 using AutoFixture;
 using CPS.ComplexCases.ActivityLog.Services;
 using CPS.ComplexCases.API.Domain.Models;
+using CPS.ComplexCases.API.Exceptions;
 using CPS.ComplexCases.API.Functions;
 using CPS.ComplexCases.API.Services;
 using CPS.ComplexCases.API.Tests.Unit.Helpers;
@@ -30,7 +31,7 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions
         private readonly Mock<INetAppArgFactory> _netAppArgFactoryMock;
         private readonly Mock<IActivityLogService> _activityLogServiceMock;
         private readonly Mock<IRequestValidator> _requestValidatorMock;
-        private readonly Mock<ISecurityGroupMetadataService> _securityGroupMetadataServiceMock;
+        private readonly Mock<IUserBucketAccessService> _userBucketAccessServiceMock;
         private readonly Mock<IInitializationHandler> _initializationHandlerMock;
         private readonly CreateNetAppConnection _function;
         private readonly Fixture _fixture;
@@ -49,7 +50,7 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions
             _netAppArgFactoryMock = new Mock<INetAppArgFactory>();
             _activityLogServiceMock = new Mock<IActivityLogService>();
             _requestValidatorMock = new Mock<IRequestValidator>();
-            _securityGroupMetadataServiceMock = new Mock<ISecurityGroupMetadataService>();
+            _userBucketAccessServiceMock = new Mock<IUserBucketAccessService>();
             _initializationHandlerMock = new Mock<IInitializationHandler>();
 
             _testCorrelationId = _fixture.Create<Guid>();
@@ -57,17 +58,15 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions
             _testCmsAuthValues = _fixture.Create<string>();
             _testBearerToken = _fixture.Create<string>();
 
-            _securityGroupMetadataServiceMock
-                .Setup(s => s.GetUserSecurityGroupsAsync(It.IsAny<string>()))
-                .ReturnsAsync([
-                    new SecurityGroup
-                    {
-                        Id = _fixture.Create<Guid>(),
-                        BucketName = _testBucketName,
-                        VolumeUuid = _fixture.Create<Guid>(),
-                        DisplayName = "Test Security Group"
-                    }
-                ]);
+            _userBucketAccessServiceMock
+                .Setup(s => s.ResolveBucketAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+                .ReturnsAsync(new SecurityGroup
+                {
+                    Id = _fixture.Create<Guid>(),
+                    BucketName = _testBucketName,
+                    VolumeUuid = _fixture.Create<Guid>(),
+                    DisplayName = "Test Security Group"
+                });
 
             _function = new CreateNetAppConnection(
                 _loggerMock.Object,
@@ -76,7 +75,7 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions
                 _netAppArgFactoryMock.Object,
                 _activityLogServiceMock.Object,
                 _requestValidatorMock.Object,
-                _securityGroupMetadataServiceMock.Object,
+                _userBucketAccessServiceMock.Object,
                 _initializationHandlerMock.Object
                 );
         }
@@ -499,6 +498,135 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions
 
             // Assert — connection creation succeeded; logging failure must not surface as an error
             Assert.IsType<OkResult>(result);
+        }
+
+        [Fact]
+        public async Task Run_WhenNoBucketNameSupplied_PersistsResolvedBucket()
+        {
+            // Arrange
+            var netAppConnectionRequest = _fixture.Create<CreateNetAppConnectionDto>();
+            netAppConnectionRequest.BucketName = null;
+
+            ArrangeSuccessfulConnect(netAppConnectionRequest);
+
+            var request = HttpRequestStubHelper.CreateHttpRequestFor(netAppConnectionRequest);
+            var functionContext = FunctionContextStubHelper.CreateFunctionContextStub(_testCorrelationId, _testCmsAuthValues, _testUsername, _testBearerToken);
+
+            // Act
+            var result = await _function.Run(request, functionContext);
+
+            // Assert
+            Assert.IsType<OkResult>(result);
+            _caseMetadataServiceMock.Verify(
+                x => x.CreateNetAppConnectionAsync(It.Is<CreateNetAppConnectionDto>(dto => dto.BucketName == _testBucketName)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Run_WhenBucketNameSupplied_ValidatesAgainstEntitlementAndPersistsIt()
+        {
+            // Arrange
+            var requestedBucket = "manchester-bucket";
+            var netAppConnectionRequest = _fixture.Create<CreateNetAppConnectionDto>();
+            netAppConnectionRequest.BucketName = requestedBucket;
+
+            _userBucketAccessServiceMock
+                .Setup(s => s.ResolveBucketAsync(_testBearerToken, null, requestedBucket))
+                .ReturnsAsync(new SecurityGroup
+                {
+                    Id = _fixture.Create<Guid>(),
+                    BucketName = requestedBucket,
+                    VolumeUuid = _fixture.Create<Guid>(),
+                    DisplayName = "Manchester"
+                });
+
+            var netAppArg = _fixture.Create<ListFoldersInBucketArg>();
+
+            _requestValidatorMock
+                .Setup(x => x.GetJsonBody<CreateNetAppConnectionDto, CreateNetAppConnectionValidator>(It.IsAny<HttpRequest>()))
+                .ReturnsAsync(new ValidatableRequest<CreateNetAppConnectionDto>
+                {
+                    IsValid = true,
+                    Value = netAppConnectionRequest
+                });
+
+            _netAppArgFactoryMock
+                .Setup(x => x.CreateListFoldersInBucketArg(_testBearerToken, requestedBucket, netAppConnectionRequest.OperationName, null, 1, null))
+                .Returns(netAppArg);
+
+            _netAppClientMock
+                .Setup(x => x.ListFoldersInBucketAsync(netAppArg))
+                .ReturnsAsync(_fixture.Create<ListNetAppObjectsDto>());
+
+            _caseMetadataServiceMock
+                .Setup(x => x.GetCaseMetadataForNetAppFolderPathsAsync(It.IsAny<IEnumerable<string>>()))
+                .ReturnsAsync(Enumerable.Empty<CaseMetadata>());
+
+            var request = HttpRequestStubHelper.CreateHttpRequestFor(netAppConnectionRequest);
+            var functionContext = FunctionContextStubHelper.CreateFunctionContextStub(_testCorrelationId, _testCmsAuthValues, _testUsername, _testBearerToken);
+
+            // Act
+            var result = await _function.Run(request, functionContext);
+
+            // Assert
+            Assert.IsType<OkResult>(result);
+            _userBucketAccessServiceMock.Verify(s => s.ResolveBucketAsync(_testBearerToken, null, requestedBucket), Times.Once);
+            _caseMetadataServiceMock.Verify(
+                x => x.CreateNetAppConnectionAsync(It.Is<CreateNetAppConnectionDto>(dto => dto.BucketName == requestedBucket)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Run_WhenUserNotEntitledToRequestedBucket_ThrowsMissingSecurityGroupException()
+        {
+            // Arrange
+            var netAppConnectionRequest = _fixture.Create<CreateNetAppConnectionDto>();
+            netAppConnectionRequest.BucketName = "not-entitled-bucket";
+
+            _requestValidatorMock
+                .Setup(x => x.GetJsonBody<CreateNetAppConnectionDto, CreateNetAppConnectionValidator>(It.IsAny<HttpRequest>()))
+                .ReturnsAsync(new ValidatableRequest<CreateNetAppConnectionDto>
+                {
+                    IsValid = true,
+                    Value = netAppConnectionRequest
+                });
+
+            _userBucketAccessServiceMock
+                .Setup(s => s.ResolveBucketAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+                .ThrowsAsync(new MissingSecurityGroupException("User is not entitled to bucket 'not-entitled-bucket'."));
+
+            var request = HttpRequestStubHelper.CreateHttpRequestFor(netAppConnectionRequest);
+            var functionContext = FunctionContextStubHelper.CreateFunctionContextStub(_testCorrelationId, _testCmsAuthValues, _testUsername, _testBearerToken);
+
+            // Act & Assert — the exception middleware maps this to a 403
+            await Assert.ThrowsAsync<MissingSecurityGroupException>(() => _function.Run(request, functionContext));
+
+            _caseMetadataServiceMock.Verify(x => x.CreateNetAppConnectionAsync(It.IsAny<CreateNetAppConnectionDto>()), Times.Never);
+        }
+
+        private void ArrangeSuccessfulConnect(CreateNetAppConnectionDto netAppConnectionRequest)
+        {
+            var netAppArg = _fixture.Create<ListFoldersInBucketArg>();
+
+            _requestValidatorMock
+                .Setup(x => x.GetJsonBody<CreateNetAppConnectionDto, CreateNetAppConnectionValidator>(It.IsAny<HttpRequest>()))
+                .ReturnsAsync(new ValidatableRequest<CreateNetAppConnectionDto>
+                {
+                    IsValid = true,
+                    Value = netAppConnectionRequest
+                });
+
+            _netAppArgFactoryMock
+                .Setup(x => x.CreateListFoldersInBucketArg(_testBearerToken, _testBucketName, netAppConnectionRequest.OperationName, null, 1, null))
+                .Returns(netAppArg);
+
+            _netAppClientMock
+                .Setup(x => x.ListFoldersInBucketAsync(netAppArg))
+                .ReturnsAsync(_fixture.Create<ListNetAppObjectsDto>());
+
+            _caseMetadataServiceMock
+                .Setup(x => x.GetCaseMetadataForNetAppFolderPathsAsync(It.IsAny<IEnumerable<string>>()))
+                .ReturnsAsync(Enumerable.Empty<CaseMetadata>());
         }
     }
 }

--- a/backend/CPS.ComplexCases.API.Tests/Unit/Functions/DeleteNetAppBatchTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Functions/DeleteNetAppBatchTests.cs
@@ -36,7 +36,7 @@ public class DeleteNetAppBatchTests
     private readonly Mock<INetAppArgFactory> _netAppArgFactoryMock;
     private readonly Mock<IActivityLogService> _activityLogServiceMock;
     private readonly Mock<IRequestValidator> _requestValidatorMock;
-    private readonly Mock<ISecurityGroupMetadataService> _securityGroupMetadataServiceMock;
+    private readonly Mock<IUserBucketAccessService> _userBucketAccessServiceMock;
     private readonly Mock<ICaseMetadataService> _caseMetadataServiceMock;
     private readonly Mock<IInitializationHandler> _initializationHandlerMock;
     private readonly DeleteNetAppBatch _function;
@@ -55,7 +55,7 @@ public class DeleteNetAppBatchTests
         _netAppArgFactoryMock = new Mock<INetAppArgFactory>();
         _activityLogServiceMock = new Mock<IActivityLogService>();
         _requestValidatorMock = new Mock<IRequestValidator>();
-        _securityGroupMetadataServiceMock = new Mock<ISecurityGroupMetadataService>();
+        _userBucketAccessServiceMock = new Mock<IUserBucketAccessService>();
         _caseMetadataServiceMock = new Mock<ICaseMetadataService>();
         _initializationHandlerMock = new Mock<IInitializationHandler>();
 
@@ -92,7 +92,7 @@ public class DeleteNetAppBatchTests
             _netAppArgFactoryMock.Object,
             _activityLogServiceMock.Object,
             _requestValidatorMock.Object,
-            _securityGroupMetadataServiceMock.Object,
+            _userBucketAccessServiceMock.Object,
             _caseMetadataServiceMock.Object,
             _initializationHandlerMock.Object);
     }
@@ -115,7 +115,7 @@ public class DeleteNetAppBatchTests
         Assert.Equal(validationErrors, errors);
 
         _caseMetadataServiceMock.Verify(s => s.GetCaseMetadataForCaseIdAsync(It.IsAny<int>()), Times.Never);
-        _securityGroupMetadataServiceMock.Verify(s => s.GetUserSecurityGroupsAsync(It.IsAny<string>()), Times.Never);
+        _userBucketAccessServiceMock.Verify(s => s.ResolveBucketAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
         _netAppClientMock.Verify(c => c.DeleteFileOrFolderAsync(It.IsAny<DeleteFileOrFolderArg>()), Times.Never);
     }
 
@@ -787,24 +787,25 @@ public class DeleteNetAppBatchTests
     }
 
     [Fact]
-    public async Task Run_UsesFirstSecurityGroupBucketName()
+    public async Task Run_WhenCaseHasNoPersistedBucket_FallsBackToResolvedBucket()
     {
-        // Arrange
+        // Arrange — covers cases connected before the bucket was persisted on CaseMetadata
         const string path = "CaseRoot/evidence.pdf";
-        const string firstBucket = "first-bucket";
-        const string secondBucket = "second-bucket";
+        const string fallbackBucket = "first-bucket";
         var dto = MakeBatchDto(1, [MaterialOp(path)]);
 
         SetupRequestValidator(dto, isValid: true);
         SetupCaseMetadata();
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(_testBearerToken))
-            .ReturnsAsync(
-            [
-                new() { Id = _fixture.Create<Guid>(), BucketName = firstBucket, VolumeUuid = _fixture.Create<Guid>(), DisplayName = "First" },
-                new() { Id = _fixture.Create<Guid>(), BucketName = secondBucket, VolumeUuid = _fixture.Create<Guid>(), DisplayName = "Second" }
-            ]);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, null, null))
+            .ReturnsAsync(new SecurityGroup
+            {
+                Id = _fixture.Create<Guid>(),
+                BucketName = fallbackBucket,
+                VolumeUuid = _fixture.Create<Guid>(),
+                DisplayName = "First"
+            });
 
         _netAppClientMock
             .Setup(c => c.DeleteFileOrFolderAsync(It.IsAny<DeleteFileOrFolderArg>()))
@@ -817,7 +818,47 @@ public class DeleteNetAppBatchTests
 
         // Assert
         _netAppArgFactoryMock.Verify(
-            f => f.CreateDeleteFileOrFolderArg(_testBearerToken, firstBucket, string.Empty, path, false),
+            f => f.CreateDeleteFileOrFolderArg(_testBearerToken, fallbackBucket, string.Empty, path, false),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Run_WhenCaseHasPersistedBucket_UsesPersistedBucket()
+    {
+        // Arrange
+        const string path = "CaseRoot/evidence.pdf";
+        const string persistedBucket = "manchester-bucket";
+        var dto = MakeBatchDto(1, [MaterialOp(path)]);
+
+        SetupRequestValidator(dto, isValid: true);
+
+        _caseMetadataServiceMock
+            .Setup(s => s.GetCaseMetadataForCaseIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(new CaseMetadata { CaseId = 1, NetappFolderPath = "CaseRoot/", NetappBucketName = persistedBucket });
+
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, persistedBucket, null))
+            .ReturnsAsync(new SecurityGroup
+            {
+                Id = _fixture.Create<Guid>(),
+                BucketName = persistedBucket,
+                VolumeUuid = _fixture.Create<Guid>(),
+                DisplayName = "Manchester"
+            });
+
+        _netAppClientMock
+            .Setup(c => c.DeleteFileOrFolderAsync(It.IsAny<DeleteFileOrFolderArg>()))
+            .ReturnsAsync(new DeleteNetAppResult(true, true, 1, null, null));
+
+        var (req, ctx) = CreateRequestAndContext();
+
+        // Act
+        await _function.Run(req, ctx);
+
+        // Assert
+        _userBucketAccessServiceMock.Verify(s => s.ResolveBucketAsync(_testBearerToken, persistedBucket, null), Times.Once);
+        _netAppArgFactoryMock.Verify(
+            f => f.CreateDeleteFileOrFolderArg(_testBearerToken, persistedBucket, string.Empty, path, false),
             Times.Once);
     }
 
@@ -829,8 +870,8 @@ public class DeleteNetAppBatchTests
         SetupRequestValidator(dto, isValid: true);
         SetupCaseMetadata();
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(_testBearerToken))
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, It.IsAny<string?>(), It.IsAny<string?>()))
             .ThrowsAsync(new MissingSecurityGroupException("No security groups found."));
 
         var (req, ctx) = CreateRequestAndContext();
@@ -1003,9 +1044,9 @@ public class DeleteNetAppBatchTests
 
     private void SetupSecurityGroups()
     {
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(_testBearerToken))
-            .ReturnsAsync(_defaultSecurityGroups);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(_testBearerToken, It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(_defaultSecurityGroups[0]);
     }
 
     private void SetupClientSuccess(string path, bool isFolder, int keysDeleted)

--- a/backend/CPS.ComplexCases.API.Tests/Unit/Functions/GetCaseMaterialPreviewTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Functions/GetCaseMaterialPreviewTests.cs
@@ -5,8 +5,13 @@ using CPS.ComplexCases.API.Functions;
 using CPS.ComplexCases.API.Services;
 using CPS.ComplexCases.API.Tests.Unit.Helpers;
 using CPS.ComplexCases.Common.Handlers;
+<<<<<<< Updated upstream
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+=======
+using CPS.ComplexCases.Common.Services;
+using CPS.ComplexCases.Data.Entities;
+>>>>>>> Stashed changes
 using Moq;
 
 namespace CPS.ComplexCases.API.Tests.Unit.Functions;
@@ -14,7 +19,8 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions;
 public class GetCaseMaterialPreviewTests
 {
     private readonly Mock<ILogger<GetCaseMaterialPreview>> _loggerMock;
-    private readonly Mock<ISecurityGroupMetadataService> _securityGroupMetadataServiceMock;
+    private readonly Mock<IUserBucketAccessService> _userBucketAccessServiceMock;
+    private readonly Mock<ICaseMetadataService> _caseMetadataServiceMock;
     private readonly Mock<IDocumentService> _documentServiceMock;
     private readonly Mock<IInitializationHandler> _initializationHandlerMock;
     private readonly Fixture _fixture;
@@ -27,7 +33,8 @@ public class GetCaseMaterialPreviewTests
     public GetCaseMaterialPreviewTests()
     {
         _loggerMock = new Mock<ILogger<GetCaseMaterialPreview>>();
-        _securityGroupMetadataServiceMock = new Mock<ISecurityGroupMetadataService>();
+        _userBucketAccessServiceMock = new Mock<IUserBucketAccessService>();
+        _caseMetadataServiceMock = new Mock<ICaseMetadataService>();
         _documentServiceMock = new Mock<IDocumentService>();
         _initializationHandlerMock = new Mock<IInitializationHandler>();
         _fixture = new Fixture();
@@ -37,21 +44,20 @@ public class GetCaseMaterialPreviewTests
         _testCorrelationId = _fixture.Create<Guid>();
         _testUsername = _fixture.Create<string>();
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(It.IsAny<string>()))
-            .ReturnsAsync([
-                new SecurityGroup
-                {
-                    Id = _fixture.Create<Guid>(),
-                    BucketName = _testBucketName,
-                    VolumeUuid = _fixture.Create<Guid>(),
-                    DisplayName = "Test Security Group"
-                }
-            ]);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(new SecurityGroup
+            {
+                Id = _fixture.Create<Guid>(),
+                BucketName = _testBucketName,
+                VolumeUuid = _fixture.Create<Guid>(),
+                DisplayName = "Test Security Group"
+            });
 
         _function = new GetCaseMaterialPreview(
             _loggerMock.Object,
-            _securityGroupMetadataServiceMock.Object,
+            _userBucketAccessServiceMock.Object,
+            _caseMetadataServiceMock.Object,
             _documentServiceMock.Object,
             _initializationHandlerMock.Object);
     }
@@ -88,6 +94,34 @@ public class GetCaseMaterialPreviewTests
         // Assert
         Assert.IsType<BadRequestObjectResult>(result);
         _documentServiceMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Run_WhenCaseIdSupplied_ResolvesUsingPersistedBucket()
+    {
+        // Arrange
+        var path = "/case/documents/evidence.pdf";
+        var caseId = 12345;
+        var persistedBucket = "manchester-bucket";
+
+        _caseMetadataServiceMock
+            .Setup(s => s.GetCaseMetadataForCaseIdAsync(caseId))
+            .ReturnsAsync(new CaseMetadata { CaseId = caseId, NetappBucketName = persistedBucket });
+
+        var functionContext = FunctionContextStubHelper.CreateFunctionContextStub(
+            _testCorrelationId, _fixture.Create<string>(), _testUsername, _testBearerToken);
+        var httpRequest = HttpRequestStubHelper.CreateHttpRequestWithQueryParameters(new Dictionary<string, string>
+        {
+            [InputParameters.Path] = path,
+            [InputParameters.CaseId] = caseId.ToString()
+        });
+
+        // Act
+        await _function.Run(httpRequest, functionContext);
+
+        // Assert
+        _userBucketAccessServiceMock.Verify(
+            s => s.ResolveBucketAsync(_testBearerToken, persistedBucket, null), Times.Once);
     }
 
     [Fact]

--- a/backend/CPS.ComplexCases.API.Tests/Unit/Functions/GetUserBucketsTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Functions/GetUserBucketsTests.cs
@@ -1,0 +1,144 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using AutoFixture;
+using CPS.ComplexCases.API.Domain.Models;
+using CPS.ComplexCases.API.Domain.Response;
+using CPS.ComplexCases.API.Exceptions;
+using CPS.ComplexCases.API.Functions;
+using CPS.ComplexCases.API.Services;
+using CPS.ComplexCases.API.Tests.Unit.Helpers;
+using CPS.ComplexCases.Common.Handlers;
+using Moq;
+
+namespace CPS.ComplexCases.API.Tests.Unit.Functions;
+
+public class GetUserBucketsTests
+{
+    private readonly Mock<ILogger<GetUserBuckets>> _loggerMock;
+    private readonly Mock<IUserBucketAccessService> _userBucketAccessServiceMock;
+    private readonly Mock<IInitializationHandler> _initializationHandlerMock;
+    private readonly GetUserBuckets _function;
+    private readonly Fixture _fixture;
+    private readonly Guid _testCorrelationId;
+    private readonly string _testUsername;
+    private readonly string _testCmsAuthValues;
+    private readonly string _testBearerToken;
+
+    public GetUserBucketsTests()
+    {
+        _fixture = new Fixture();
+        _loggerMock = new Mock<ILogger<GetUserBuckets>>();
+        _userBucketAccessServiceMock = new Mock<IUserBucketAccessService>();
+        _initializationHandlerMock = new Mock<IInitializationHandler>();
+
+        _testCorrelationId = _fixture.Create<Guid>();
+        _testUsername = _fixture.Create<string>();
+        _testCmsAuthValues = _fixture.Create<string>();
+        _testBearerToken = _fixture.Create<string>();
+
+        _function = new GetUserBuckets(
+            _loggerMock.Object,
+            _userBucketAccessServiceMock.Object,
+            _initializationHandlerMock.Object);
+    }
+
+    [Fact]
+    public async Task Run_WhenUserEntitledToOneBucket_ReturnsSingleEntry()
+    {
+        // Arrange
+        var bucket = MakeSecurityGroup("york-bucket", "York");
+
+        _userBucketAccessServiceMock
+            .Setup(s => s.GetEntitledBucketsAsync(_testBearerToken))
+            .ReturnsAsync([bucket]);
+
+        // Act
+        var result = await _function.Run(
+            HttpRequestStubHelper.CreateHttpRequest(_testCorrelationId),
+            CreateFunctionContext());
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<ListUserBucketsResponse>(okResult.Value);
+
+        var entry = Assert.Single(response.Buckets);
+        Assert.Equal(bucket.Id, entry.Id);
+        Assert.Equal("york-bucket", entry.Name);
+        Assert.Equal("York", entry.DisplayName);
+    }
+
+    [Fact]
+    public async Task Run_WhenUserEntitledToTwoBuckets_ReturnsBothEntries()
+    {
+        // Arrange
+        _userBucketAccessServiceMock
+            .Setup(s => s.GetEntitledBucketsAsync(_testBearerToken))
+            .ReturnsAsync([
+                MakeSecurityGroup("york-bucket", "York"),
+                MakeSecurityGroup("manchester-bucket", "Manchester")
+            ]);
+
+        // Act
+        var result = await _function.Run(
+            HttpRequestStubHelper.CreateHttpRequest(_testCorrelationId),
+            CreateFunctionContext());
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<ListUserBucketsResponse>(okResult.Value);
+
+        Assert.Collection(response.Buckets,
+            first =>
+            {
+                Assert.Equal("york-bucket", first.Name);
+                Assert.Equal("York", first.DisplayName);
+            },
+            second =>
+            {
+                Assert.Equal("manchester-bucket", second.Name);
+                Assert.Equal("Manchester", second.DisplayName);
+            });
+    }
+
+    [Fact]
+    public async Task Run_WhenUserHasNoGroupMatch_ThrowsMissingSecurityGroupException()
+    {
+        // Arrange
+        _userBucketAccessServiceMock
+            .Setup(s => s.GetEntitledBucketsAsync(_testBearerToken))
+            .ThrowsAsync(new MissingSecurityGroupException("No matching security groups found for the provided IDs."));
+
+        // Act & Assert — the exception middleware maps this to a 403
+        await Assert.ThrowsAsync<MissingSecurityGroupException>(() => _function.Run(
+            HttpRequestStubHelper.CreateHttpRequest(_testCorrelationId),
+            CreateFunctionContext()));
+    }
+
+    [Fact]
+    public async Task Run_InitializesHandlerWithUsernameAndCorrelationId()
+    {
+        // Arrange
+        _userBucketAccessServiceMock
+            .Setup(s => s.GetEntitledBucketsAsync(_testBearerToken))
+            .ReturnsAsync([MakeSecurityGroup("york-bucket", "York")]);
+
+        // Act
+        await _function.Run(
+            HttpRequestStubHelper.CreateHttpRequest(_testCorrelationId),
+            CreateFunctionContext());
+
+        // Assert
+        _initializationHandlerMock.Verify(h => h.Initialize(_testUsername, _testCorrelationId, null), Times.Once);
+    }
+
+    private SecurityGroup MakeSecurityGroup(string bucketName, string displayName) => new()
+    {
+        Id = _fixture.Create<Guid>(),
+        BucketName = bucketName,
+        VolumeUuid = _fixture.Create<Guid>(),
+        DisplayName = displayName
+    };
+
+    private Microsoft.Azure.Functions.Worker.FunctionContext CreateFunctionContext() =>
+        FunctionContextStubHelper.CreateFunctionContextStub(_testCorrelationId, _testCmsAuthValues, _testUsername, _testBearerToken);
+}

--- a/backend/CPS.ComplexCases.API.Tests/Unit/Functions/InitiateBatchCopyTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Functions/InitiateBatchCopyTests.cs
@@ -24,7 +24,7 @@ public class InitiateBatchCopyTests
     private readonly Mock<ILogger<InitiateBatchCopy>> _loggerMock;
     private readonly Mock<IFileTransferClient> _fileTransferClientMock;
     private readonly Mock<IRequestValidator> _requestValidatorMock;
-    private readonly Mock<ISecurityGroupMetadataService> _securityGroupMetadataServiceMock;
+    private readonly Mock<IUserBucketAccessService> _userBucketAccessServiceMock;
     private readonly Mock<ICaseMetadataService> _caseMetadataServiceMock;
     private readonly Mock<IInitializationHandler> _initializationHandlerMock;
     private readonly InitiateBatchCopy _function;
@@ -44,7 +44,7 @@ public class InitiateBatchCopyTests
         _loggerMock = new Mock<ILogger<InitiateBatchCopy>>();
         _fileTransferClientMock = new Mock<IFileTransferClient>();
         _requestValidatorMock = new Mock<IRequestValidator>();
-        _securityGroupMetadataServiceMock = new Mock<ISecurityGroupMetadataService>();
+        _userBucketAccessServiceMock = new Mock<IUserBucketAccessService>();
         _caseMetadataServiceMock = new Mock<ICaseMetadataService>();
         _initializationHandlerMock = new Mock<IInitializationHandler>();
 
@@ -57,9 +57,9 @@ public class InitiateBatchCopyTests
 
         _defaultSecurityGroups = [new() { Id = _fixture.Create<Guid>(), BucketName = _testBucketName, VolumeUuid = _fixture.Create<Guid>(), DisplayName = "Test" }];
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(It.IsAny<string>()))
-            .ReturnsAsync(_defaultSecurityGroups);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(_defaultSecurityGroups[0]);
 
         _caseMetadataServiceMock
             .Setup(s => s.GetCaseMetadataForCaseIdAsync(It.IsAny<int>()))
@@ -73,7 +73,7 @@ public class InitiateBatchCopyTests
             _loggerMock.Object,
             _fileTransferClientMock.Object,
             _requestValidatorMock.Object,
-            _securityGroupMetadataServiceMock.Object,
+            _userBucketAccessServiceMock.Object,
             _caseMetadataServiceMock.Object,
             _initializationHandlerMock.Object);
     }

--- a/backend/CPS.ComplexCases.API.Tests/Unit/Functions/ListNetAppFilesTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Functions/ListNetAppFilesTests.cs
@@ -5,6 +5,8 @@ using CPS.ComplexCases.API.Functions;
 using CPS.ComplexCases.API.Services;
 using CPS.ComplexCases.API.Tests.Unit.Helpers;
 using CPS.ComplexCases.Common.Handlers;
+using CPS.ComplexCases.Common.Services;
+using CPS.ComplexCases.Data.Entities;
 using CPS.ComplexCases.NetApp.Client;
 using CPS.ComplexCases.NetApp.Factories;
 using CPS.ComplexCases.NetApp.Models.Args;
@@ -20,7 +22,8 @@ public class ListNetAppFilesTests
     private readonly Mock<ILogger<ListNetAppFiles>> _loggerMock;
     private readonly Mock<INetAppClient> _netAppClientMock;
     private readonly Mock<INetAppArgFactory> _netAppArgFactoryMock;
-    private readonly Mock<ISecurityGroupMetadataService> _securityGroupMetadataServiceMock;
+    private readonly Mock<IUserBucketAccessService> _userBucketAccessServiceMock;
+    private readonly Mock<ICaseMetadataService> _caseMetadataServiceMock;
     private readonly Mock<IInitializationHandler> _initializationHandlerMock;
     private readonly ListNetAppFiles _function;
     private readonly Fixture _fixture;
@@ -35,7 +38,8 @@ public class ListNetAppFilesTests
         _loggerMock = new Mock<ILogger<ListNetAppFiles>>();
         _netAppClientMock = new Mock<INetAppClient>();
         _netAppArgFactoryMock = new Mock<INetAppArgFactory>();
-        _securityGroupMetadataServiceMock = new Mock<ISecurityGroupMetadataService>();
+        _userBucketAccessServiceMock = new Mock<IUserBucketAccessService>();
+        _caseMetadataServiceMock = new Mock<ICaseMetadataService>();
         _initializationHandlerMock = new Mock<IInitializationHandler>();
         _fixture = new Fixture();
 
@@ -45,23 +49,22 @@ public class ListNetAppFilesTests
         _testUsername = _fixture.Create<string>();
         _testCmsAuthValues = _fixture.Create<string>();
 
-        _securityGroupMetadataServiceMock
-                .Setup(s => s.GetUserSecurityGroupsAsync(It.IsAny<string>()))
-                .ReturnsAsync([
-                    new SecurityGroup
-                    {
-                        Id = _fixture.Create<Guid>(),
-                        BucketName = _testBucketName,
-                        VolumeUuid = _fixture.Create<Guid>(),
-                        DisplayName = "Test Security Group"
-                    }
-                ]);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(new SecurityGroup
+            {
+                Id = _fixture.Create<Guid>(),
+                BucketName = _testBucketName,
+                VolumeUuid = _fixture.Create<Guid>(),
+                DisplayName = "Test Security Group"
+            });
 
         _function = new ListNetAppFiles(
             _loggerMock.Object,
             _netAppClientMock.Object,
             _netAppArgFactoryMock.Object,
-            _securityGroupMetadataServiceMock.Object,
+            _userBucketAccessServiceMock.Object,
+            _caseMetadataServiceMock.Object,
             _initializationHandlerMock.Object);
     }
 
@@ -152,5 +155,66 @@ public class ListNetAppFilesTests
         var result = await _function.Run(httpRequest, functionContext);
         // Assert
         Assert.IsType<BadRequestResult>(result);
+    }
+
+    [Fact]
+    public async Task Run_WhenCaseIdSupplied_ResolvesUsingPersistedBucket()
+    {
+        // Arrange
+        var caseId = 12345;
+        var persistedBucket = "manchester-bucket";
+
+        _caseMetadataServiceMock
+            .Setup(s => s.GetCaseMetadataForCaseIdAsync(caseId))
+            .ReturnsAsync(new CaseMetadata { CaseId = caseId, NetappBucketName = persistedBucket });
+
+        var queryParams = new Dictionary<string, string>
+        {
+            [InputParameters.Take] = "50",
+            [InputParameters.Path] = "/some/path",
+            [InputParameters.CaseId] = caseId.ToString()
+        };
+        var httpRequest = HttpRequestStubHelper.CreateHttpRequestWithQueryParameters(queryParams);
+
+        _netAppArgFactoryMock
+            .Setup(f => f.CreateListObjectsInBucketArg(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>()))
+            .Returns(_fixture.Create<ListObjectsInBucketArg>());
+
+        var functionContext = FunctionContextStubHelper.CreateFunctionContextStub(_testCorrelationId, _testCmsAuthValues, _testUsername, _testBearerToken);
+
+        // Act
+        await _function.Run(httpRequest, functionContext);
+
+        // Assert
+        _userBucketAccessServiceMock.Verify(
+            s => s.ResolveBucketAsync(_testBearerToken, persistedBucket, null), Times.Once);
+    }
+
+    [Fact]
+    public async Task Run_WhenNoCaseIdSupplied_FallsBackWithoutPersistedBucket()
+    {
+        // Arrange
+        var queryParams = new Dictionary<string, string>
+        {
+            [InputParameters.Take] = "50",
+            [InputParameters.Path] = "/some/path"
+        };
+        var httpRequest = HttpRequestStubHelper.CreateHttpRequestWithQueryParameters(queryParams);
+
+        _netAppArgFactoryMock
+            .Setup(f => f.CreateListObjectsInBucketArg(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>()))
+            .Returns(_fixture.Create<ListObjectsInBucketArg>());
+
+        var functionContext = FunctionContextStubHelper.CreateFunctionContextStub(_testCorrelationId, _testCmsAuthValues, _testUsername, _testBearerToken);
+
+        // Act
+        await _function.Run(httpRequest, functionContext);
+
+        // Assert
+        _userBucketAccessServiceMock.Verify(
+            s => s.ResolveBucketAsync(_testBearerToken, null, null), Times.Once);
+        _caseMetadataServiceMock.Verify(s => s.GetCaseMetadataForCaseIdAsync(It.IsAny<int>()), Times.Never);
     }
 }

--- a/backend/CPS.ComplexCases.API.Tests/Unit/Functions/ListNetAppFoldersTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Functions/ListNetAppFoldersTests.cs
@@ -5,7 +5,10 @@ using CPS.ComplexCases.API.Domain.Response;
 using CPS.ComplexCases.API.Functions;
 using CPS.ComplexCases.API.Services;
 using CPS.ComplexCases.API.Tests.Unit.Helpers;
+using CPS.ComplexCases.API.Exceptions;
 using CPS.ComplexCases.Common.Handlers;
+using CPS.ComplexCases.Common.Services;
+using CPS.ComplexCases.Data.Entities;
 using CPS.ComplexCases.NetApp.Client;
 using CPS.ComplexCases.NetApp.Factories;
 using CPS.ComplexCases.NetApp.Models.Args;
@@ -22,7 +25,8 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions
         private readonly Mock<INetAppClient> _netAppClientMock;
         private readonly Mock<INetAppArgFactory> _netAppArgFactoryMock;
         private readonly Mock<ICaseEnrichmentService> _caseEnrichmentServiceMock;
-        private readonly Mock<ISecurityGroupMetadataService> _securityGroupMetadataServiceMock;
+        private readonly Mock<IUserBucketAccessService> _userBucketAccessServiceMock;
+        private readonly Mock<ICaseMetadataService> _caseMetadataServiceMock;
         private readonly Mock<IInitializationHandler> _initializationHandlerMock;
         private readonly Fixture _fixture;
         private readonly ListNetAppFolders _function;
@@ -38,7 +42,8 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions
             _netAppClientMock = new Mock<INetAppClient>();
             _netAppArgFactoryMock = new Mock<INetAppArgFactory>();
             _caseEnrichmentServiceMock = new Mock<ICaseEnrichmentService>();
-            _securityGroupMetadataServiceMock = new Mock<ISecurityGroupMetadataService>();
+            _userBucketAccessServiceMock = new Mock<IUserBucketAccessService>();
+            _caseMetadataServiceMock = new Mock<ICaseMetadataService>();
             _initializationHandlerMock = new Mock<IInitializationHandler>();
             _fixture = new Fixture();
 
@@ -48,24 +53,23 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions
             _testUsername = _fixture.Create<string>();
             _testCmsAuthValues = _fixture.Create<string>();
 
-            _securityGroupMetadataServiceMock
-                .Setup(s => s.GetUserSecurityGroupsAsync(It.IsAny<string>()))
-                .ReturnsAsync([
-                    new SecurityGroup
-                    {
-                        Id = _fixture.Create<Guid>(),
-                        BucketName = _testBucketName,
-                        VolumeUuid = _fixture.Create<Guid>(),
-                        DisplayName = "Test Security Group"
-                    }
-                ]);
+            _userBucketAccessServiceMock
+                .Setup(s => s.ResolveBucketAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+                .ReturnsAsync(new SecurityGroup
+                {
+                    Id = _fixture.Create<Guid>(),
+                    BucketName = _testBucketName,
+                    VolumeUuid = _fixture.Create<Guid>(),
+                    DisplayName = "Test Security Group"
+                });
 
             _function = new ListNetAppFolders(
                 _loggerMock.Object,
                 _netAppClientMock.Object,
                 _netAppArgFactoryMock.Object,
                 _caseEnrichmentServiceMock.Object,
-                _securityGroupMetadataServiceMock.Object,
+                _userBucketAccessServiceMock.Object,
+                _caseMetadataServiceMock.Object,
                 _initializationHandlerMock.Object);
         }
 
@@ -164,6 +168,107 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions
             // Assert
             Assert.IsType<BadRequestResult>(result);
             _caseEnrichmentServiceMock.Verify(s => s.EnrichNetAppFoldersWithMetadataAsync(It.IsAny<ListNetAppObjectsDto>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Run_WhenCaseIdSupplied_ResolvesUsingPersistedBucket()
+        {
+            // Arrange
+            var caseId = 12345;
+            var persistedBucket = "manchester-bucket";
+
+            _caseMetadataServiceMock
+                .Setup(s => s.GetCaseMetadataForCaseIdAsync(caseId))
+                .ReturnsAsync(new CaseMetadata { CaseId = caseId, NetappBucketName = persistedBucket });
+
+            var queryParams = new Dictionary<string, string>
+            {
+                [InputParameters.OperationName] = "opName",
+                [InputParameters.Take] = "50",
+                [InputParameters.Path] = "/some/path",
+                [InputParameters.CaseId] = caseId.ToString()
+            };
+
+            ArrangeNetAppCall(queryParams);
+
+            var functionContext = FunctionContextStubHelper.CreateFunctionContextStub(_testCorrelationId, _testCmsAuthValues, _testUsername, _testBearerToken);
+
+            // Act
+            await _function.Run(HttpRequestStubHelper.CreateHttpRequestWithQueryParameters(queryParams), functionContext);
+
+            // Assert
+            _userBucketAccessServiceMock.Verify(
+                s => s.ResolveBucketAsync(_testBearerToken, persistedBucket, null), Times.Once);
+        }
+
+        [Fact]
+        public async Task Run_WhenBucketNameSupplied_PassesItThroughForValidation()
+        {
+            // Arrange
+            var requestedBucket = "manchester-bucket";
+
+            var queryParams = new Dictionary<string, string>
+            {
+                [InputParameters.OperationName] = "opName",
+                [InputParameters.Take] = "50",
+                [InputParameters.Path] = "/some/path",
+                [InputParameters.BucketName] = requestedBucket
+            };
+
+            ArrangeNetAppCall(queryParams);
+
+            var functionContext = FunctionContextStubHelper.CreateFunctionContextStub(_testCorrelationId, _testCmsAuthValues, _testUsername, _testBearerToken);
+
+            // Act
+            await _function.Run(HttpRequestStubHelper.CreateHttpRequestWithQueryParameters(queryParams), functionContext);
+
+            // Assert
+            _userBucketAccessServiceMock.Verify(
+                s => s.ResolveBucketAsync(_testBearerToken, null, requestedBucket), Times.Once);
+        }
+
+        [Fact]
+        public async Task Run_WhenUserNotEntitledToRequestedBucket_ThrowsMissingSecurityGroupException()
+        {
+            // Arrange
+            var queryParams = new Dictionary<string, string>
+            {
+                [InputParameters.OperationName] = "opName",
+                [InputParameters.Take] = "50",
+                [InputParameters.Path] = "/some/path",
+                [InputParameters.BucketName] = "not-entitled-bucket"
+            };
+
+            _userBucketAccessServiceMock
+                .Setup(s => s.ResolveBucketAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+                .ThrowsAsync(new MissingSecurityGroupException("User is not entitled to bucket 'not-entitled-bucket'."));
+
+            var functionContext = FunctionContextStubHelper.CreateFunctionContextStub(_testCorrelationId, _testCmsAuthValues, _testUsername, _testBearerToken);
+
+            // Act & Assert — the exception middleware maps this to a 403
+            await Assert.ThrowsAsync<MissingSecurityGroupException>(() =>
+                _function.Run(HttpRequestStubHelper.CreateHttpRequestWithQueryParameters(queryParams), functionContext));
+
+            _netAppClientMock.Verify(c => c.ListFoldersInBucketAsync(It.IsAny<ListFoldersInBucketArg>()), Times.Never);
+        }
+
+        private void ArrangeNetAppCall(Dictionary<string, string> queryParams)
+        {
+            var arg = _fixture.Create<ListFoldersInBucketArg>();
+            var response = _fixture.Create<ListNetAppObjectsDto>();
+
+            _netAppArgFactoryMock
+                .Setup(f => f.CreateListFoldersInBucketArg(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+                .Returns(arg);
+
+            _netAppClientMock
+                .Setup(c => c.ListFoldersInBucketAsync(arg))
+                .ReturnsAsync(response);
+
+            _caseEnrichmentServiceMock
+                .Setup(s => s.EnrichNetAppFoldersWithMetadataAsync(response))
+                .ReturnsAsync(_fixture.Create<ListNetAppObjectsResponse>());
         }
     }
 }

--- a/backend/CPS.ComplexCases.API.Tests/Unit/Functions/ProvisionNetAppFoldersTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Functions/ProvisionNetAppFoldersTests.cs
@@ -38,7 +38,7 @@ public class ProvisionNetAppFoldersTests
     private readonly Mock<ICaseNamingService> _caseNamingServiceMock;
     private readonly Mock<IFileTransferClient> _fileTransferClientMock;
     private readonly Mock<IRequestValidator> _requestValidatorMock;
-    private readonly Mock<ISecurityGroupMetadataService> _securityGroupMetadataServiceMock;
+    private readonly Mock<IUserBucketAccessService> _userBucketAccessServiceMock;
     private readonly Mock<ICaseMetadataService> _caseMetadataServiceMock;
     private readonly Mock<IActivityLogService> _activityLogServiceMock;
     private readonly Mock<IInitializationHandler> _initializationHandlerMock;
@@ -64,7 +64,7 @@ public class ProvisionNetAppFoldersTests
         _caseNamingServiceMock = new Mock<ICaseNamingService>();
         _fileTransferClientMock = new Mock<IFileTransferClient>();
         _requestValidatorMock = new Mock<IRequestValidator>();
-        _securityGroupMetadataServiceMock = new Mock<ISecurityGroupMetadataService>();
+        _userBucketAccessServiceMock = new Mock<IUserBucketAccessService>();
         _caseMetadataServiceMock = new Mock<ICaseMetadataService>();
         _activityLogServiceMock = new Mock<IActivityLogService>();
         _initializationHandlerMock = new Mock<IInitializationHandler>();
@@ -79,17 +79,15 @@ public class ProvisionNetAppFoldersTests
         _operationName = _fixture.Create<string>();
         _caseNameDto = new CaseNameDto { CaseName = _caseName, OperationName = _operationName };
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(It.IsAny<string>()))
-            .ReturnsAsync([
-                new SecurityGroup
-                {
-                    Id = _fixture.Create<Guid>(),
-                    BucketName = _bucketName,
-                    VolumeUuid = _fixture.Create<Guid>(),
-                    DisplayName = "Test Security Group"
-                }
-            ]);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(new SecurityGroup
+            {
+                Id = _fixture.Create<Guid>(),
+                BucketName = _bucketName,
+                VolumeUuid = _fixture.Create<Guid>(),
+                DisplayName = "Test Security Group"
+            });
 
         _function = new ProvisionNetAppFolders(
             _loggerMock.Object,
@@ -98,7 +96,7 @@ public class ProvisionNetAppFoldersTests
             _caseNamingServiceMock.Object,
             _fileTransferClientMock.Object,
             _requestValidatorMock.Object,
-            _securityGroupMetadataServiceMock.Object,
+            _userBucketAccessServiceMock.Object,
             _caseMetadataServiceMock.Object,
             _activityLogServiceMock.Object,
             _initializationHandlerMock.Object);

--- a/backend/CPS.ComplexCases.API.Tests/Unit/Functions/SearchNetAppFoldersTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Functions/SearchNetAppFoldersTests.cs
@@ -27,7 +27,7 @@ public class SearchNetAppFoldersTests
     private readonly Mock<INetAppClient> _netAppClientMock;
     private readonly Mock<INetAppArgFactory> _netAppArgFactoryMock;
     private readonly Mock<ICaseMetadataService> _caseMetadataServiceMock;
-    private readonly Mock<ISecurityGroupMetadataService> _securityGroupMetadataServiceMock;
+    private readonly Mock<IUserBucketAccessService> _userBucketAccessServiceMock;
     private readonly Mock<IInitializationHandler> _initializationHandlerMock;
     private readonly IValidator<SearchNetAppFoldersDto> _validator;
     private readonly SearchNetAppFolders _function;
@@ -44,7 +44,7 @@ public class SearchNetAppFoldersTests
         _netAppClientMock = new Mock<INetAppClient>();
         _netAppArgFactoryMock = new Mock<INetAppArgFactory>();
         _caseMetadataServiceMock = new Mock<ICaseMetadataService>();
-        _securityGroupMetadataServiceMock = new Mock<ISecurityGroupMetadataService>();
+        _userBucketAccessServiceMock = new Mock<IUserBucketAccessService>();
         _initializationHandlerMock = new Mock<IInitializationHandler>();
         _validator = new SearchNetAppFoldersRequestValidator();
         _fixture = new Fixture();
@@ -55,24 +55,22 @@ public class SearchNetAppFoldersTests
         _testUsername = _fixture.Create<string>();
         _testCmsAuthValues = _fixture.Create<string>();
 
-        _securityGroupMetadataServiceMock
-            .Setup(s => s.GetUserSecurityGroupsAsync(It.IsAny<string>()))
-            .ReturnsAsync([
-                new SecurityGroup
-                {
-                    Id = _fixture.Create<Guid>(),
-                    BucketName = _testBucketName,
-                    VolumeUuid = _fixture.Create<Guid>(),
-                    DisplayName = "Test Security Group"
-                }
-            ]);
+        _userBucketAccessServiceMock
+            .Setup(s => s.ResolveBucketAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(new SecurityGroup
+            {
+                Id = _fixture.Create<Guid>(),
+                BucketName = _testBucketName,
+                VolumeUuid = _fixture.Create<Guid>(),
+                DisplayName = "Test Security Group"
+            });
 
         _function = new SearchNetAppFolders(
             _loggerMock.Object,
             _netAppClientMock.Object,
             _netAppArgFactoryMock.Object,
             _caseMetadataServiceMock.Object,
-            _securityGroupMetadataServiceMock.Object,
+            _userBucketAccessServiceMock.Object,
             _initializationHandlerMock.Object,
             _validator);
     }

--- a/backend/CPS.ComplexCases.API.Tests/Unit/Functions/Transfer/GetFilesForTransferTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Functions/Transfer/GetFilesForTransferTests.cs
@@ -17,6 +17,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
+<<<<<<< Updated upstream
+=======
+using CPS.ComplexCases.API.Services;
+using CPS.ComplexCases.API.Domain.Models;
+using CPS.ComplexCases.Common.Services;
+>>>>>>> Stashed changes
 
 namespace CPS.ComplexCases.API.Tests.Unit.Functions.Transfer
 {
@@ -25,7 +31,8 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions.Transfer
         private readonly Mock<IFileTransferClient> _transferClientMock;
         private readonly Mock<ILogger<GetFilesForTransfer>> _loggerMock;
         private readonly Mock<IRequestValidator> _requestValidatorMock;
-        private readonly Mock<ISecurityGroupMetadataService> _securityGroupMetadataServiceMock;
+        private readonly Mock<IUserBucketAccessService> _userBucketAccessServiceMock;
+        private readonly Mock<ICaseMetadataService> _caseMetadataServiceMock;
         private readonly string _testBucketName;
         private readonly GetFilesForTransfer _function;
         private readonly Guid _correlationId;
@@ -39,26 +46,26 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions.Transfer
             _transferClientMock = new Mock<IFileTransferClient>();
             _loggerMock = new Mock<ILogger<GetFilesForTransfer>>();
             _requestValidatorMock = new Mock<IRequestValidator>();
-            _securityGroupMetadataServiceMock = new Mock<ISecurityGroupMetadataService>();
+            _userBucketAccessServiceMock = new Mock<IUserBucketAccessService>();
+            _caseMetadataServiceMock = new Mock<ICaseMetadataService>();
             _testBucketName = _fixture.Create<string>();
 
-            _securityGroupMetadataServiceMock
-                .Setup(s => s.GetUserSecurityGroupsAsync(It.IsAny<string>()))
-                .ReturnsAsync([
-                    new SecurityGroup
-            {
-                Id = _fixture.Create<Guid>(),
-                BucketName = _testBucketName,
-                VolumeUuid = _fixture.Create<Guid>(),
-                DisplayName = "Test Security Group"
-            }
-                ]);
+            _userBucketAccessServiceMock
+                .Setup(s => s.ResolveBucketAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+                .ReturnsAsync(new SecurityGroup
+                {
+                    Id = _fixture.Create<Guid>(),
+                    BucketName = _testBucketName,
+                    VolumeUuid = _fixture.Create<Guid>(),
+                    DisplayName = "Test Security Group"
+                });
 
             _function = new GetFilesForTransfer(
                 _transferClientMock.Object,
                 _loggerMock.Object,
                 _requestValidatorMock.Object,
-                _securityGroupMetadataServiceMock.Object);
+                _userBucketAccessServiceMock.Object,
+                _caseMetadataServiceMock.Object);
         }
 
         [Fact]

--- a/backend/CPS.ComplexCases.API.Tests/Unit/Functions/Transfer/InitiateTransferTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Functions/Transfer/InitiateTransferTests.cs
@@ -16,6 +16,13 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
+<<<<<<< Updated upstream
+=======
+using CPS.ComplexCases.API.Services;
+using CPS.ComplexCases.API.Domain.Models;
+using CPS.ComplexCases.Common.Services;
+using CPS.ComplexCases.Data.Entities;
+>>>>>>> Stashed changes
 
 namespace CPS.ComplexCases.API.Tests.Unit.Functions.Transfer
 {
@@ -24,7 +31,8 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions.Transfer
         private readonly Mock<ILogger<InitiateTransfer>> _loggerMock;
         private readonly Mock<IFileTransferClient> _fileTransferClientMock;
         private readonly Mock<IRequestValidator> _requestValidatorMock;
-        private readonly Mock<ISecurityGroupMetadataService> _securityGroupMetadataServiceMock;
+        private readonly Mock<IUserBucketAccessService> _userBucketAccessServiceMock;
+        private readonly Mock<ICaseMetadataService> _caseMetadataServiceMock;
         private readonly InitiateTransfer _function;
         private readonly Fixture _fixture;
         private readonly Guid _testCorrelationId;
@@ -38,30 +46,30 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions.Transfer
             _loggerMock = new Mock<ILogger<InitiateTransfer>>();
             _fileTransferClientMock = new Mock<IFileTransferClient>();
             _requestValidatorMock = new Mock<IRequestValidator>();
-            _securityGroupMetadataServiceMock = new Mock<ISecurityGroupMetadataService>();
+            _userBucketAccessServiceMock = new Mock<IUserBucketAccessService>();
+            _caseMetadataServiceMock = new Mock<ICaseMetadataService>();
 
             _testCorrelationId = _fixture.Create<Guid>();
             _testUsername = _fixture.Create<string>();
             _testCmsAuthValues = _fixture.Create<string>();
             _testBearerToken = _fixture.Create<string>();
 
-            _securityGroupMetadataServiceMock
-                .Setup(s => s.GetUserSecurityGroupsAsync(It.IsAny<string>()))
-                .ReturnsAsync([
-                    new SecurityGroup
-                    {
-                        Id = _fixture.Create<Guid>(),
-                        BucketName = "test-bucket",
-                        VolumeUuid = _fixture.Create<Guid>(),
-                        DisplayName = "Test Security Group"
-                    }
-                ]);
+            _userBucketAccessServiceMock
+                .Setup(s => s.ResolveBucketAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+                .ReturnsAsync(new SecurityGroup
+                {
+                    Id = _fixture.Create<Guid>(),
+                    BucketName = "test-bucket",
+                    VolumeUuid = _fixture.Create<Guid>(),
+                    DisplayName = "Test Security Group"
+                });
 
             _function = new InitiateTransfer(
                 _loggerMock.Object,
                 _fileTransferClientMock.Object,
                 _requestValidatorMock.Object,
-                _securityGroupMetadataServiceMock.Object
+                _userBucketAccessServiceMock.Object,
+                _caseMetadataServiceMock.Object
             );
         }
 
@@ -146,6 +154,63 @@ namespace CPS.ComplexCases.API.Tests.Unit.Functions.Transfer
             ), It.IsAny<Guid>()), Times.Once);
 
             Assert.IsType<ContentResult>(result);
+        }
+
+        [Fact]
+        public async Task Run_SnapshotsPersistedBucketOntoTransferMetadata()
+        {
+            // Arrange
+            var caseId = 123;
+            var persistedBucket = "manchester-bucket";
+
+            var initiateRequest = new InitiateTransferRequest
+            {
+                TransferType = TransferType.Copy,
+                TransferDirection = TransferDirection.EgressToNetApp,
+                DestinationPath = "/destination",
+                CaseId = caseId,
+                WorkspaceId = "workspace-1",
+                SourcePaths = [new SourcePath { Path = "/source/file1.txt", FileId = "file1" }]
+            };
+
+            _requestValidatorMock
+                .Setup(v => v.GetJsonBody<InitiateTransferRequest, InitiateTransferRequestValidator>(It.IsAny<HttpRequest>()))
+                .ReturnsAsync(new ValidatableRequest<InitiateTransferRequest>
+                {
+                    IsValid = true,
+                    Value = initiateRequest
+                });
+
+            _caseMetadataServiceMock
+                .Setup(s => s.GetCaseMetadataForCaseIdAsync(caseId))
+                .ReturnsAsync(new CaseMetadata { CaseId = caseId, NetappBucketName = persistedBucket });
+
+            _userBucketAccessServiceMock
+                .Setup(s => s.ResolveBucketAsync(_testBearerToken, persistedBucket, null))
+                .ReturnsAsync(new SecurityGroup
+                {
+                    Id = _fixture.Create<Guid>(),
+                    BucketName = persistedBucket,
+                    VolumeUuid = _fixture.Create<Guid>(),
+                    DisplayName = "Manchester"
+                });
+
+            _fileTransferClientMock
+                .Setup(c => c.InitiateFileTransferAsync(It.IsAny<TransferRequest>(), It.IsAny<Guid>()))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("Transfer initiated", Encoding.UTF8, "application/json")
+                });
+
+            var request = HttpRequestStubHelper.CreateHttpRequestFor(initiateRequest);
+            var functionContext = FunctionContextStubHelper.CreateFunctionContextStub(_testCorrelationId, _testCmsAuthValues, _testUsername, _testBearerToken);
+
+            // Act
+            await _function.Run(request, functionContext);
+
+            // Assert
+            _fileTransferClientMock.Verify(c => c.InitiateFileTransferAsync(
+                It.Is<TransferRequest>(r => r.Metadata.BucketName == persistedBucket), It.IsAny<Guid>()), Times.Once);
         }
     }
 }

--- a/backend/CPS.ComplexCases.API.Tests/Unit/Services/UserBucketAccessServiceTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Services/UserBucketAccessServiceTests.cs
@@ -1,0 +1,211 @@
+using Microsoft.Extensions.Logging;
+using AutoFixture;
+using CPS.ComplexCases.API.Domain.Models;
+using CPS.ComplexCases.API.Exceptions;
+using CPS.ComplexCases.API.Services;
+using Moq;
+
+namespace CPS.ComplexCases.API.Tests.Unit.Services;
+
+public class UserBucketAccessServiceTests
+{
+    private readonly Mock<ILogger<UserBucketAccessService>> _loggerMock;
+    private readonly Mock<ISecurityGroupMetadataService> _securityGroupMetadataServiceMock;
+    private readonly UserBucketAccessService _service;
+    private readonly Fixture _fixture;
+    private readonly string _bearerToken;
+
+    private const string YorkBucket = "york-bucket";
+    private const string ManchesterBucket = "manchester-bucket";
+
+    public UserBucketAccessServiceTests()
+    {
+        _fixture = new Fixture();
+        _loggerMock = new Mock<ILogger<UserBucketAccessService>>();
+        _securityGroupMetadataServiceMock = new Mock<ISecurityGroupMetadataService>();
+        _bearerToken = _fixture.Create<string>();
+
+        _service = new UserBucketAccessService(_loggerMock.Object, _securityGroupMetadataServiceMock.Object);
+    }
+
+    [Fact]
+    public async Task GetEntitledBucketsAsync_ReturnsAllEntitledBuckets()
+    {
+        // Arrange
+        SetupEntitlements(YorkBucket, ManchesterBucket);
+
+        // Act
+        var result = await _service.GetEntitledBucketsAsync(_bearerToken);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, x => x.BucketName == YorkBucket);
+        Assert.Contains(result, x => x.BucketName == ManchesterBucket);
+    }
+
+    [Fact]
+    public async Task GetEntitledBucketsAsync_PropagatesMissingSecurityGroupException_WhenNoEntitlements()
+    {
+        // Arrange
+        _securityGroupMetadataServiceMock
+            .Setup(s => s.GetUserSecurityGroupsAsync(_bearerToken))
+            .ThrowsAsync(new MissingSecurityGroupException("No matching security groups found for the provided IDs."));
+
+        // Act & Assert — the exception middleware maps this to a 403
+        await Assert.ThrowsAsync<MissingSecurityGroupException>(() => _service.GetEntitledBucketsAsync(_bearerToken));
+    }
+
+    [Fact]
+    public async Task EnsureBucketAllowedAsync_ReturnsBucket_WhenEntitled()
+    {
+        // Arrange
+        SetupEntitlements(YorkBucket, ManchesterBucket);
+
+        // Act
+        var result = await _service.EnsureBucketAllowedAsync(_bearerToken, ManchesterBucket);
+
+        // Assert
+        Assert.Equal(ManchesterBucket, result.BucketName);
+    }
+
+    [Fact]
+    public async Task EnsureBucketAllowedAsync_IsCaseInsensitive()
+    {
+        // Arrange
+        SetupEntitlements(YorkBucket);
+
+        // Act
+        var result = await _service.EnsureBucketAllowedAsync(_bearerToken, YorkBucket.ToUpperInvariant());
+
+        // Assert
+        Assert.Equal(YorkBucket, result.BucketName);
+    }
+
+    [Fact]
+    public async Task EnsureBucketAllowedAsync_Throws_WhenNotEntitled()
+    {
+        // Arrange
+        SetupEntitlements(YorkBucket);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<MissingSecurityGroupException>(() =>
+            _service.EnsureBucketAllowedAsync(_bearerToken, ManchesterBucket));
+    }
+
+    [Fact]
+    public async Task ResolveBucketAsync_PrefersPersistedBucket_OverRequestedBucket()
+    {
+        // Arrange
+        SetupEntitlements(YorkBucket, ManchesterBucket);
+
+        // Act
+        var result = await _service.ResolveBucketAsync(_bearerToken, ManchesterBucket, YorkBucket);
+
+        // Assert
+        Assert.Equal(ManchesterBucket, result.BucketName);
+    }
+
+    [Fact]
+    public async Task ResolveBucketAsync_UsesRequestedBucket_WhenNothingPersisted()
+    {
+        // Arrange
+        SetupEntitlements(YorkBucket, ManchesterBucket);
+
+        // Act
+        var result = await _service.ResolveBucketAsync(_bearerToken, null, ManchesterBucket);
+
+        // Assert
+        Assert.Equal(ManchesterBucket, result.BucketName);
+    }
+
+    [Fact]
+    public async Task ResolveBucketAsync_Throws_WhenPersistedBucketNoLongerEntitled()
+    {
+        // Arrange — the user lost the AD group membership after connecting
+        SetupEntitlements(YorkBucket);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<MissingSecurityGroupException>(() =>
+            _service.ResolveBucketAsync(_bearerToken, ManchesterBucket, null));
+    }
+
+    [Fact]
+    public async Task ResolveBucketAsync_Throws_WhenRequestedBucketNotEntitled()
+    {
+        // Arrange
+        SetupEntitlements(YorkBucket);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<MissingSecurityGroupException>(() =>
+            _service.ResolveBucketAsync(_bearerToken, null, ManchesterBucket));
+    }
+
+    [Fact]
+    public async Task ResolveBucketAsync_FallsBackToFirstEntitlement_WhenNeitherSupplied()
+    {
+        // Arrange
+        SetupEntitlements(YorkBucket);
+
+        // Act
+        var result = await _service.ResolveBucketAsync(_bearerToken, null, null);
+
+        // Assert
+        Assert.Equal(YorkBucket, result.BucketName);
+    }
+
+    [Fact]
+    public async Task ResolveBucketAsync_WarnsAndFallsBackToFirst_WhenMultipleEntitlements()
+    {
+        // Arrange
+        SetupEntitlements(YorkBucket, ManchesterBucket);
+
+        // Act
+        var result = await _service.ResolveBucketAsync(_bearerToken, null, null);
+
+        // Assert
+        Assert.Equal(YorkBucket, result.BucketName);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains(YorkBucket)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ResolveBucketAsync_DoesNotWarn_WhenSingleEntitlement()
+    {
+        // Arrange
+        SetupEntitlements(YorkBucket);
+
+        // Act
+        await _service.ResolveBucketAsync(_bearerToken, null, null);
+
+        // Assert
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    private void SetupEntitlements(params string[] bucketNames)
+    {
+        var securityGroups = bucketNames.Select(bucketName => new SecurityGroup
+        {
+            Id = _fixture.Create<Guid>(),
+            BucketName = bucketName,
+            VolumeUuid = _fixture.Create<Guid>(),
+            DisplayName = bucketName
+        }).ToList();
+
+        _securityGroupMetadataServiceMock
+            .Setup(s => s.GetUserSecurityGroupsAsync(_bearerToken))
+            .ReturnsAsync(securityGroups);
+    }
+}

--- a/backend/CPS.ComplexCases.API/Constants/InputParameters.cs
+++ b/backend/CPS.ComplexCases.API/Constants/InputParameters.cs
@@ -25,5 +25,6 @@ namespace CPS.ComplexCases.API.Constants
         public const string Query = "query";
         public const string Mode = "mode";
         public const string MaxResults = "max-results";
+        public const string BucketName = "bucket-name";
     }
 }

--- a/backend/CPS.ComplexCases.API/Domain/Response/ListUserBucketsResponse.cs
+++ b/backend/CPS.ComplexCases.API/Domain/Response/ListUserBucketsResponse.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace CPS.ComplexCases.API.Domain.Response;
+
+public class ListUserBucketsResponse
+{
+  [JsonPropertyName("buckets")]
+  public required IEnumerable<UserBucketResponse> Buckets { get; set; }
+}
+
+public class UserBucketResponse
+{
+  [JsonPropertyName("id")]
+  public required Guid Id { get; set; }
+  [JsonPropertyName("name")]
+  public required string Name { get; set; }
+  [JsonPropertyName("displayName")]
+  public required string DisplayName { get; set; }
+}

--- a/backend/CPS.ComplexCases.API/Functions/CreateNetAppConnection.cs
+++ b/backend/CPS.ComplexCases.API/Functions/CreateNetAppConnection.cs
@@ -26,7 +26,7 @@ public class CreateNetAppConnection(ILogger<CreateNetAppConnection> logger,
     INetAppArgFactory netAppArgFactory,
     IActivityLogService activityLogService,
     IRequestValidator requestValidator,
-    ISecurityGroupMetadataService securityGroupMetadataService,
+    IUserBucketAccessService userBucketAccessService,
     IInitializationHandler initializationHandler)
 {
     private readonly ILogger<CreateNetAppConnection> _logger = logger;
@@ -35,7 +35,7 @@ public class CreateNetAppConnection(ILogger<CreateNetAppConnection> logger,
     private readonly INetAppArgFactory _netAppArgFactory = netAppArgFactory;
     private readonly IActivityLogService _activityLogService = activityLogService;
     private readonly IRequestValidator _requestValidator = requestValidator;
-    private readonly ISecurityGroupMetadataService _securityGroupMetadataService = securityGroupMetadataService;
+    private readonly IUserBucketAccessService _userBucketAccessService = userBucketAccessService;
     private readonly IInitializationHandler _initializationHandler = initializationHandler;
 
     [Function(nameof(CreateNetAppConnection))]
@@ -62,9 +62,10 @@ public class CreateNetAppConnection(ILogger<CreateNetAppConnection> logger,
 
         _initializationHandler.Initialize(context.Username, context.CorrelationId, netAppConnectionRequest.Value.CaseId);
 
-        var securityGroups = await _securityGroupMetadataService.GetUserSecurityGroupsAsync(context.BearerToken);
+        var bucketName = (await _userBucketAccessService.ResolveBucketAsync(
+            context.BearerToken, null, netAppConnectionRequest.Value.BucketName)).BucketName;
 
-        var netAppArg = _netAppArgFactory.CreateListFoldersInBucketArg(context.BearerToken, securityGroups.First().BucketName, netAppConnectionRequest.Value.OperationName, null, 1, null);
+        var netAppArg = _netAppArgFactory.CreateListFoldersInBucketArg(context.BearerToken, bucketName, netAppConnectionRequest.Value.OperationName, null, 1, null);
         var hasNetAppPermission = await _netAppClient.ListFoldersInBucketAsync(netAppArg);
 
         if (hasNetAppPermission == null)
@@ -73,7 +74,6 @@ public class CreateNetAppConnection(ILogger<CreateNetAppConnection> logger,
         }
 
         var folderPath = netAppConnectionRequest.Value.NetAppFolderPath;
-        var bucketName = securityGroups.First().BucketName;
         var lookupPaths = new[] { folderPath, $"{bucketName}:{folderPath}" };
         var existingConnections = await _caseMetadataService.GetCaseMetadataForNetAppFolderPathsAsync(lookupPaths);
         var existingConnection = existingConnections.FirstOrDefault();
@@ -85,6 +85,9 @@ public class CreateNetAppConnection(ILogger<CreateNetAppConnection> logger,
                 folderPath, existingConnection.CaseId, netAppConnectionRequest.Value.CaseId);
             return new ConflictObjectResult($"Folder path '{folderPath}' is already connected to another case.");
         }
+
+        // Persist the resolved bucket even when the client sent none, so every new row is populated.
+        netAppConnectionRequest.Value.BucketName = bucketName;
 
         await _caseMetadataService.CreateNetAppConnectionAsync(netAppConnectionRequest.Value);
 

--- a/backend/CPS.ComplexCases.API/Functions/CreateNetAppFolder.cs
+++ b/backend/CPS.ComplexCases.API/Functions/CreateNetAppFolder.cs
@@ -7,6 +7,7 @@ using CPS.ComplexCases.API.Validators.Requests;
 using CPS.ComplexCases.Common.Attributes;
 using CPS.ComplexCases.Common.Handlers;
 using CPS.ComplexCases.Common.Helpers;
+using CPS.ComplexCases.Common.Services;
 using CPS.ComplexCases.NetApp.Client;
 using CPS.ComplexCases.NetApp.Factories;
 using CPS.ComplexCases.NetApp.Models.Requests;
@@ -24,7 +25,8 @@ public class CreateNetAppFolder(ILogger<CreateNetAppFolder> logger,
     INetAppArgFactory netAppArgFactory,
     IActivityLogService activityLogService,
     IRequestValidator requestValidator,
-    ISecurityGroupMetadataService securityGroupMetadataService,
+    IUserBucketAccessService userBucketAccessService,
+    ICaseMetadataService caseMetadataService,
     IInitializationHandler initializationHandler)
 {
     private readonly ILogger<CreateNetAppFolder> _logger = logger;
@@ -32,7 +34,8 @@ public class CreateNetAppFolder(ILogger<CreateNetAppFolder> logger,
     private readonly INetAppArgFactory _netAppArgFactory = netAppArgFactory;
     private readonly IActivityLogService _activityLogService = activityLogService;
     private readonly IRequestValidator _requestValidator = requestValidator;
-    private readonly ISecurityGroupMetadataService _securityGroupMetadataService = securityGroupMetadataService;
+    private readonly IUserBucketAccessService _userBucketAccessService = userBucketAccessService;
+    private readonly ICaseMetadataService _caseMetadataService = caseMetadataService;
     private readonly IInitializationHandler _initializationHandler = initializationHandler;
 
     [Function(nameof(CreateNetAppFolder))]
@@ -59,8 +62,9 @@ public class CreateNetAppFolder(ILogger<CreateNetAppFolder> logger,
         var folderPath = createFolderRequest.Value.Path.TrimEnd('/');
         var caseId = createFolderRequest.Value.CaseId;
 
-        var securityGroups = await _securityGroupMetadataService.GetUserSecurityGroupsAsync(context.BearerToken);
-        var bucketName = securityGroups.First().BucketName;
+        var caseMetadata = await _caseMetadataService.GetCaseMetadataForCaseIdAsync(caseId);
+        var bucketName = (await _userBucketAccessService.ResolveBucketAsync(
+            context.BearerToken, caseMetadata?.NetappBucketName, null)).BucketName;
 
         var folderName = folderPath.Contains('/') ? folderPath[(folderPath.LastIndexOf('/') + 1)..] : folderPath;
 

--- a/backend/CPS.ComplexCases.API/Functions/DeleteNetAppBatch.cs
+++ b/backend/CPS.ComplexCases.API/Functions/DeleteNetAppBatch.cs
@@ -31,7 +31,7 @@ public class DeleteNetAppBatch(
     INetAppArgFactory netAppArgFactory,
     IActivityLogService activityLogService,
     IRequestValidator requestValidator,
-    ISecurityGroupMetadataService securityGroupMetadataService,
+    IUserBucketAccessService userBucketAccessService,
     ICaseMetadataService caseMetadataService,
     IInitializationHandler initializationHandler)
 {
@@ -40,7 +40,7 @@ public class DeleteNetAppBatch(
     private readonly INetAppArgFactory _netAppArgFactory = netAppArgFactory;
     private readonly IActivityLogService _activityLogService = activityLogService;
     private readonly IRequestValidator _requestValidator = requestValidator;
-    private readonly ISecurityGroupMetadataService _securityGroupMetadataService = securityGroupMetadataService;
+    private readonly IUserBucketAccessService _userBucketAccessService = userBucketAccessService;
     private readonly ICaseMetadataService _caseMetadataService = caseMetadataService;
     private readonly IInitializationHandler _initializationHandler = initializationHandler;
 
@@ -73,8 +73,8 @@ public class DeleteNetAppBatch(
 
         var casePrefix = caseMetadata.NetappFolderPath.EnsureTrailingSlash();
 
-        var securityGroups = await _securityGroupMetadataService.GetUserSecurityGroupsAsync(context.BearerToken);
-        var bucket = securityGroups.First().BucketName;
+        var bucket = (await _userBucketAccessService.ResolveBucketAsync(
+            context.BearerToken, caseMetadata.NetappBucketName, null)).BucketName;
 
         var results = new List<DeleteNetAppBatchItemResult>();
 

--- a/backend/CPS.ComplexCases.API/Functions/GetCaseMaterialPreview.cs
+++ b/backend/CPS.ComplexCases.API/Functions/GetCaseMaterialPreview.cs
@@ -4,22 +4,28 @@ using CPS.ComplexCases.API.Context;
 using CPS.ComplexCases.API.Services;
 using CPS.ComplexCases.Common.Attributes;
 using CPS.ComplexCases.Common.Handlers;
+<<<<<<< Updated upstream
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
+=======
+using CPS.ComplexCases.Common.Services;
+>>>>>>> Stashed changes
 
 namespace CPS.ComplexCases.API.Functions;
 
 public class GetCaseMaterialPreview(
     ILogger<GetCaseMaterialPreview> logger,
-    ISecurityGroupMetadataService securityGroupMetadataService,
+    IUserBucketAccessService userBucketAccessService,
+    ICaseMetadataService caseMetadataService,
     IDocumentService documentService,
     IInitializationHandler initializationHandler)
 {
     private readonly ILogger<GetCaseMaterialPreview> _logger = logger;
-    private readonly ISecurityGroupMetadataService _securityGroupMetadataService = securityGroupMetadataService;
+    private readonly IUserBucketAccessService _userBucketAccessService = userBucketAccessService;
+    private readonly ICaseMetadataService _caseMetadataService = caseMetadataService;
     private readonly IDocumentService _documentService = documentService;
     private readonly IInitializationHandler _initializationHandler = initializationHandler;
 
@@ -27,6 +33,7 @@ public class GetCaseMaterialPreview(
     [OpenApiOperation(operationId: nameof(GetCaseMaterialPreview), tags: ["NetApp"], Description = "Retrieves a case material document from NetApp and returns it as a PDF preview.")]
     [BearerTokenAuth]
     [OpenApiParameter(name: InputParameters.Path, In = Microsoft.OpenApi.Models.ParameterLocation.Query, Required = true, Type = typeof(string), Description = "The NetApp path of the document to preview.")]
+    [OpenApiParameter(name: InputParameters.CaseId, In = Microsoft.OpenApi.Models.ParameterLocation.Query, Required = false, Type = typeof(int), Description = "The case ID, used to read the bucket already connected to the case.")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/pdf", bodyType: typeof(FileStreamResult), Description = ApiResponseDescriptions.Success)]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: ContentType.TextPlain, typeof(string), Description = ApiResponseDescriptions.BadRequest)]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: ContentType.TextPlain, typeof(string), Description = ApiResponseDescriptions.NotFound)]
@@ -47,8 +54,15 @@ public class GetCaseMaterialPreview(
             return new BadRequestObjectResult($"Query parameter '{InputParameters.Path}' is required.");
         }
 
-        var securityGroups = await _securityGroupMetadataService.GetUserSecurityGroupsAsync(context.BearerToken);
-        var bucketName = securityGroups.First().BucketName;
+        string? persistedBucketName = null;
+        if (int.TryParse(req.Query[InputParameters.CaseId], out var caseId) && caseId > 0)
+        {
+            var caseMetadata = await _caseMetadataService.GetCaseMetadataForCaseIdAsync(caseId);
+            persistedBucketName = caseMetadata?.NetappBucketName;
+        }
+
+        var bucketName = (await _userBucketAccessService.ResolveBucketAsync(
+            context.BearerToken, persistedBucketName, null)).BucketName;
 
         var result = await _documentService.GetMaterialPreviewAsync(path, context.BearerToken, bucketName);
 

--- a/backend/CPS.ComplexCases.API/Functions/GetUserBuckets.cs
+++ b/backend/CPS.ComplexCases.API/Functions/GetUserBuckets.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Extensions.Logging;
+using CPS.ComplexCases.API.Constants;
+using CPS.ComplexCases.API.Context;
+using CPS.ComplexCases.API.Domain.Response;
+using CPS.ComplexCases.API.Services;
+using CPS.ComplexCases.Common.Attributes;
+using CPS.ComplexCases.Common.Handlers;
+
+namespace CPS.ComplexCases.API.Functions;
+
+public class GetUserBuckets(
+    ILogger<GetUserBuckets> logger,
+    IUserBucketAccessService userBucketAccessService,
+    IInitializationHandler initializationHandler)
+{
+    private readonly ILogger<GetUserBuckets> _logger = logger;
+    private readonly IUserBucketAccessService _userBucketAccessService = userBucketAccessService;
+    private readonly IInitializationHandler _initializationHandler = initializationHandler;
+
+    [Function(nameof(GetUserBuckets))]
+    [OpenApiOperation(operationId: nameof(GetUserBuckets), tags: ["NetApp"], Description = "Lists the NetApp buckets the user is entitled to, based on their token groups claim.")]
+    [BearerTokenAuth]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: ContentType.ApplicationJson, bodyType: typeof(ListUserBucketsResponse), Description = ApiResponseDescriptions.Success)]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Unauthorized, contentType: ContentType.TextPlain, typeof(string), Description = ApiResponseDescriptions.Unauthorized)]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Forbidden, contentType: ContentType.TextPlain, typeof(string), Description = ApiResponseDescriptions.Forbidden)]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.InternalServerError, contentType: ContentType.TextPlain, typeof(string), Description = ApiResponseDescriptions.InternalServerError)]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/netapp/buckets")] HttpRequest req,
+        FunctionContext functionContext)
+    {
+        var context = functionContext.GetRequestContext();
+        _initializationHandler.Initialize(context.Username, context.CorrelationId);
+
+        var entitledBuckets = await _userBucketAccessService.GetEntitledBucketsAsync(context.BearerToken);
+
+        _logger.LogInformation("Resolved {BucketCount} entitled NetApp buckets for the user.", entitledBuckets.Count);
+
+        return new OkObjectResult(new ListUserBucketsResponse
+        {
+            Buckets = entitledBuckets.Select(bucket => new UserBucketResponse
+            {
+                Id = bucket.Id,
+                Name = bucket.BucketName,
+                DisplayName = bucket.DisplayName
+            }).ToList()
+        });
+    }
+}

--- a/backend/CPS.ComplexCases.API/Functions/InitiateBatchCopy.cs
+++ b/backend/CPS.ComplexCases.API/Functions/InitiateBatchCopy.cs
@@ -21,10 +21,10 @@ public class InitiateBatchCopy(
     ILogger<InitiateBatchCopy> logger,
     IFileTransferClient transferClient,
     IRequestValidator requestValidator,
-    ISecurityGroupMetadataService securityGroupMetadataService,
+    IUserBucketAccessService userBucketAccessService,
     ICaseMetadataService caseMetadataService,
     IInitializationHandler initializationHandler)
-    : InitiateBatchOperationBase(logger, transferClient, requestValidator, securityGroupMetadataService, caseMetadataService, initializationHandler)
+    : InitiateBatchOperationBase(logger, transferClient, requestValidator, userBucketAccessService, caseMetadataService, initializationHandler)
 {
     [Function(nameof(InitiateBatchCopy))]
     [OpenApiOperation(operationId: nameof(InitiateBatchCopy), tags: ["NetApp"], Description = "Initiates an asynchronous batch copy of files and folders within NetApp. Returns a transferId that can be polled for status.")]

--- a/backend/CPS.ComplexCases.API/Functions/InitiateBatchOperationBase.cs
+++ b/backend/CPS.ComplexCases.API/Functions/InitiateBatchOperationBase.cs
@@ -18,14 +18,14 @@ public abstract class InitiateBatchOperationBase(
     ILogger logger,
     IFileTransferClient transferClient,
     IRequestValidator requestValidator,
-    ISecurityGroupMetadataService securityGroupMetadataService,
+    IUserBucketAccessService userBucketAccessService,
     ICaseMetadataService caseMetadataService,
     IInitializationHandler initializationHandler)
 {
     private readonly ILogger _logger = logger;
     protected readonly IFileTransferClient _transferClient = transferClient;
     private readonly IRequestValidator _requestValidator = requestValidator;
-    private readonly ISecurityGroupMetadataService _securityGroupMetadataService = securityGroupMetadataService;
+    private readonly IUserBucketAccessService _userBucketAccessService = userBucketAccessService;
     private readonly ICaseMetadataService _caseMetadataService = caseMetadataService;
     private readonly IInitializationHandler _initializationHandler = initializationHandler;
 
@@ -84,12 +84,13 @@ public abstract class InitiateBatchOperationBase(
             return new BadRequestObjectResult(new[] { "The destination prefix is not within the case's NetApp folder." });
         }
 
-        var securityGroups = await _securityGroupMetadataService.GetUserSecurityGroupsAsync(context.BearerToken);
+        var bucket = await _userBucketAccessService.ResolveBucketAsync(
+            context.BearerToken, caseMetadata.NetappBucketName, null);
 
         var response = await executeAsync(
             batchRequest.Value,
             context.BearerToken,
-            securityGroups.First().BucketName,
+            bucket.BucketName,
             context.Username,
             context.CorrelationId);
 

--- a/backend/CPS.ComplexCases.API/Functions/ListNetAppFiles.cs
+++ b/backend/CPS.ComplexCases.API/Functions/ListNetAppFiles.cs
@@ -4,6 +4,7 @@ using CPS.ComplexCases.API.Context;
 using CPS.ComplexCases.API.Services;
 using CPS.ComplexCases.Common.Attributes;
 using CPS.ComplexCases.Common.Handlers;
+using CPS.ComplexCases.Common.Services;
 using CPS.ComplexCases.NetApp.Client;
 using CPS.ComplexCases.NetApp.Factories;
 using CPS.ComplexCases.NetApp.Models.Dto;
@@ -16,12 +17,13 @@ using Microsoft.OpenApi.Models;
 
 namespace CPS.ComplexCases.API.Functions;
 
-public class ListNetAppFiles(ILogger<ListNetAppFiles> logger, INetAppClient netAppClient, INetAppArgFactory netAppArgFactory, ISecurityGroupMetadataService securityGroupMetadataService, IInitializationHandler initializationHandler)
+public class ListNetAppFiles(ILogger<ListNetAppFiles> logger, INetAppClient netAppClient, INetAppArgFactory netAppArgFactory, IUserBucketAccessService userBucketAccessService, ICaseMetadataService caseMetadataService, IInitializationHandler initializationHandler)
 {
     private readonly ILogger<ListNetAppFiles> _logger = logger;
     private readonly INetAppClient _netAppClient = netAppClient;
     private readonly INetAppArgFactory _netAppArgFactory = netAppArgFactory;
-    private readonly ISecurityGroupMetadataService _securityGroupMetadataService = securityGroupMetadataService;
+    private readonly IUserBucketAccessService _userBucketAccessService = userBucketAccessService;
+    private readonly ICaseMetadataService _caseMetadataService = caseMetadataService;
     private readonly IInitializationHandler _initializationHandler = initializationHandler;
 
     [Function(nameof(ListNetAppFiles))]
@@ -31,6 +33,7 @@ public class ListNetAppFiles(ILogger<ListNetAppFiles> logger, INetAppClient netA
     [OpenApiParameter(name: InputParameters.Path, In = ParameterLocation.Query, Required = false, Type = typeof(string), Description = "The path to the destination folder.")]
     [OpenApiParameter(name: InputParameters.Take, In = ParameterLocation.Query, Required = false, Type = typeof(int), Description = "The number of items to take.")]
     [OpenApiParameter(name: InputParameters.ContinuationToken, In = ParameterLocation.Query, Type = typeof(string), Description = "The continuation token for pagination.")]
+    [OpenApiParameter(name: InputParameters.CaseId, In = ParameterLocation.Query, Required = false, Type = typeof(int), Description = "The case ID, used to read the bucket already connected to the case.")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: ContentType.ApplicationJson, bodyType: typeof(ListNetAppObjectsDto), Description = ApiResponseDescriptions.Success)]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: ContentType.TextPlain, typeof(string), Description = ApiResponseDescriptions.BadRequest)]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Unauthorized, contentType: ContentType.TextPlain, typeof(string), Description = ApiResponseDescriptions.Unauthorized)]
@@ -45,9 +48,17 @@ public class ListNetAppFiles(ILogger<ListNetAppFiles> logger, INetAppClient netA
         var take = int.TryParse(req.Query[InputParameters.Take], out var takeValue) ? takeValue : 100;
         var path = req.Query[InputParameters.Path];
 
-        var securityGroups = await _securityGroupMetadataService.GetUserSecurityGroupsAsync(context.BearerToken);
+        string? persistedBucketName = null;
+        if (int.TryParse(req.Query[InputParameters.CaseId], out var caseId) && caseId > 0)
+        {
+            var caseMetadata = await _caseMetadataService.GetCaseMetadataForCaseIdAsync(caseId);
+            persistedBucketName = caseMetadata?.NetappBucketName;
+        }
 
-        var arg = _netAppArgFactory.CreateListObjectsInBucketArg(context.BearerToken, securityGroups.First().BucketName, continuationToken, take, path, true);
+        var bucket = await _userBucketAccessService.ResolveBucketAsync(
+            context.BearerToken, persistedBucketName, null);
+
+        var arg = _netAppArgFactory.CreateListObjectsInBucketArg(context.BearerToken, bucket.BucketName, continuationToken, take, path, true);
         var response = await _netAppClient.ListObjectsInBucketAsync(arg);
 
         if (response == null)

--- a/backend/CPS.ComplexCases.API/Functions/ListNetAppFolders.cs
+++ b/backend/CPS.ComplexCases.API/Functions/ListNetAppFolders.cs
@@ -5,6 +5,7 @@ using CPS.ComplexCases.API.Domain.Response;
 using CPS.ComplexCases.API.Services;
 using CPS.ComplexCases.Common.Attributes;
 using CPS.ComplexCases.Common.Handlers;
+using CPS.ComplexCases.Common.Services;
 using CPS.ComplexCases.NetApp.Client;
 using CPS.ComplexCases.NetApp.Factories;
 using Microsoft.AspNetCore.Http;
@@ -20,14 +21,16 @@ public class ListNetAppFolders(ILogger<ListNetAppFolders> logger,
     INetAppClient netAppClient,
     INetAppArgFactory netAppArgFactory,
     ICaseEnrichmentService caseEnrichmentService,
-    ISecurityGroupMetadataService securityGroupMetadataService,
+    IUserBucketAccessService userBucketAccessService,
+    ICaseMetadataService caseMetadataService,
     IInitializationHandler initializationHandler)
 {
     private readonly ILogger<ListNetAppFolders> _logger = logger;
     private readonly INetAppClient _netAppClient = netAppClient;
     private readonly INetAppArgFactory _netAppArgFactory = netAppArgFactory;
     private readonly ICaseEnrichmentService _caseEnrichmentService = caseEnrichmentService;
-    private readonly ISecurityGroupMetadataService _securityGroupMetadataService = securityGroupMetadataService;
+    private readonly IUserBucketAccessService _userBucketAccessService = userBucketAccessService;
+    private readonly ICaseMetadataService _caseMetadataService = caseMetadataService;
     private readonly IInitializationHandler _initializationHandler = initializationHandler;
 
     [Function(nameof(ListNetAppFolders))]
@@ -38,6 +41,8 @@ public class ListNetAppFolders(ILogger<ListNetAppFolders> logger,
     [OpenApiParameter(name: InputParameters.Path, In = ParameterLocation.Query, Required = false, Type = typeof(string), Description = "The path to the destination folder.")]
     [OpenApiParameter(name: InputParameters.Take, In = ParameterLocation.Query, Required = false, Type = typeof(int), Description = "The number of items to take.")]
     [OpenApiParameter(name: InputParameters.ContinuationToken, In = ParameterLocation.Query, Type = typeof(string), Description = "The continuation token for pagination.")]
+    [OpenApiParameter(name: InputParameters.CaseId, In = ParameterLocation.Query, Required = false, Type = typeof(int), Description = "The case ID, used to read the bucket already connected to the case.")]
+    [OpenApiParameter(name: InputParameters.BucketName, In = ParameterLocation.Query, Required = false, Type = typeof(string), Description = "The bucket to browse, for use before the case has a connected bucket.")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: ContentType.ApplicationJson, bodyType: typeof(ListNetAppObjectsResponse), Description = ApiResponseDescriptions.Success)]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: ContentType.TextPlain, typeof(string), Description = ApiResponseDescriptions.BadRequest)]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Unauthorized, contentType: ContentType.TextPlain, typeof(string), Description = ApiResponseDescriptions.Unauthorized)]
@@ -52,10 +57,19 @@ public class ListNetAppFolders(ILogger<ListNetAppFolders> logger,
         var continuationToken = req.Query[InputParameters.ContinuationToken];
         var take = int.TryParse(req.Query[InputParameters.Take], out var takeValue) ? takeValue : 100;
         var path = req.Query[InputParameters.Path];
+        var requestedBucketName = req.Query[InputParameters.BucketName].FirstOrDefault();
 
-        var securityGroups = await _securityGroupMetadataService.GetUserSecurityGroupsAsync(context.BearerToken);
+        string? persistedBucketName = null;
+        if (int.TryParse(req.Query[InputParameters.CaseId], out var caseId) && caseId > 0)
+        {
+            var caseMetadata = await _caseMetadataService.GetCaseMetadataForCaseIdAsync(caseId);
+            persistedBucketName = caseMetadata?.NetappBucketName;
+        }
 
-        var arg = _netAppArgFactory.CreateListFoldersInBucketArg(context.BearerToken, securityGroups.First().BucketName, operationName, continuationToken, take, path);
+        var bucket = await _userBucketAccessService.ResolveBucketAsync(
+            context.BearerToken, persistedBucketName, requestedBucketName);
+
+        var arg = _netAppArgFactory.CreateListFoldersInBucketArg(context.BearerToken, bucket.BucketName, operationName, continuationToken, take, path);
         var response = await _netAppClient.ListFoldersInBucketAsync(arg);
 
         if (response == null)

--- a/backend/CPS.ComplexCases.API/Functions/ProvisionNetAppFolders.cs
+++ b/backend/CPS.ComplexCases.API/Functions/ProvisionNetAppFolders.cs
@@ -31,7 +31,7 @@ public class ProvisionNetAppFolders(ILogger<ProvisionNetAppFolders> logger,
     ICaseNamingService caseNamingService,
     IFileTransferClient transferClient,
     IRequestValidator requestValidator,
-    ISecurityGroupMetadataService securityGroupMetadataService,
+    IUserBucketAccessService userBucketAccessService,
     ICaseMetadataService caseMetadataService,
     IActivityLogService activityLogService,
     IInitializationHandler initializationHandler)
@@ -42,7 +42,7 @@ public class ProvisionNetAppFolders(ILogger<ProvisionNetAppFolders> logger,
     private readonly ICaseNamingService _caseNamingService = caseNamingService;
     private readonly IFileTransferClient _transferClient = transferClient;
     private readonly IRequestValidator _requestValidator = requestValidator;
-    private readonly ISecurityGroupMetadataService _securityGroupMetadataService = securityGroupMetadataService;
+    private readonly IUserBucketAccessService _userBucketAccessService = userBucketAccessService;
     private readonly ICaseMetadataService _caseMetadataService = caseMetadataService;
     private readonly IActivityLogService _activityLogService = activityLogService;
     private readonly IInitializationHandler _initializationHandler = initializationHandler;
@@ -99,7 +99,8 @@ public class ProvisionNetAppFolders(ILogger<ProvisionNetAppFolders> logger,
         var caseNameDto = await _caseNamingService.GenerateCaseName(cmsResponse);
         var folderPathName = caseNameDto.CaseName.EnsureTrailingSlash();
 
-        var securityGroups = await _securityGroupMetadataService.GetUserSecurityGroupsAsync(context.BearerToken);
+        var bucketName = (await _userBucketAccessService.ResolveBucketAsync(
+            context.BearerToken, caseMetadata?.NetappBucketName, provisionFoldersRequest.Value.BucketName)).BucketName;
 
         var provisionNetAppFoldersRequest = new ProvisionNetAppFoldersRequest
         {
@@ -107,7 +108,7 @@ public class ProvisionNetAppFolders(ILogger<ProvisionNetAppFolders> logger,
             Urn = cmsResponse.Urn,
             TemplateName = provisionFoldersRequest.Value.TemplateFolderPath,
             DestinationFolderPath = folderPathName,
-            BucketName = securityGroups.First().BucketName,
+            BucketName = bucketName,
             BearerToken = context.BearerToken,
             CaseName = caseNameDto.CaseName,
             OperationName = caseNameDto.OperationName,
@@ -160,7 +161,8 @@ public class ProvisionNetAppFolders(ILogger<ProvisionNetAppFolders> logger,
         {
             CaseId = caseId,
             NetAppFolderPath = folderPathName,
-            OperationName = caseNameDto.OperationName
+            OperationName = caseNameDto.OperationName,
+            BucketName = bucketName
         });
 
         try

--- a/backend/CPS.ComplexCases.API/Functions/SearchNetAppFolders.cs
+++ b/backend/CPS.ComplexCases.API/Functions/SearchNetAppFolders.cs
@@ -25,7 +25,7 @@ public class SearchNetAppFolders(
     INetAppClient netAppClient,
     INetAppArgFactory netAppArgFactory,
     ICaseMetadataService caseMetadataService,
-    ISecurityGroupMetadataService securityGroupMetadataService,
+    IUserBucketAccessService userBucketAccessService,
     IInitializationHandler initializationHandler,
     IValidator<SearchNetAppFoldersDto> validator)
 {
@@ -33,7 +33,7 @@ public class SearchNetAppFolders(
     private readonly INetAppClient _netAppClient = netAppClient;
     private readonly INetAppArgFactory _netAppArgFactory = netAppArgFactory;
     private readonly ICaseMetadataService _caseMetadataService = caseMetadataService;
-    private readonly ISecurityGroupMetadataService _securityGroupMetadataService = securityGroupMetadataService;
+    private readonly IUserBucketAccessService _userBucketAccessService = userBucketAccessService;
     private readonly IValidator<SearchNetAppFoldersDto> _validator = validator;
     private readonly IInitializationHandler _initializationHandler = initializationHandler;
 
@@ -78,9 +78,10 @@ public class SearchNetAppFolders(
             return new BadRequestObjectResult("Case metadata or NetApp folder path is missing.");
         }
 
-        var securityGroups = await _securityGroupMetadataService.GetUserSecurityGroupsAsync(context.BearerToken);
+        var bucket = await _userBucketAccessService.ResolveBucketAsync(
+            context.BearerToken, caseMetadata.NetappBucketName, null);
 
-        var arg = _netAppArgFactory.CreateSearchArg(context.BearerToken, securityGroups.First().BucketName, caseMetadata.NetappFolderPath!, request.Query, request.MaxResults, request.Mode);
+        var arg = _netAppArgFactory.CreateSearchArg(context.BearerToken, bucket.BucketName, caseMetadata.NetappFolderPath!, request.Query, request.MaxResults, request.Mode);
         var response = await _netAppClient.SearchObjectsInBucketAsync(arg);
 
         return new OkObjectResult(response);

--- a/backend/CPS.ComplexCases.API/Functions/Transfer/GetFilesForTransfer.cs
+++ b/backend/CPS.ComplexCases.API/Functions/Transfer/GetFilesForTransfer.cs
@@ -15,15 +15,30 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+<<<<<<< Updated upstream
+=======
+using CPS.ComplexCases.API.Clients.FileTransfer;
+using CPS.ComplexCases.API.Constants;
+using CPS.ComplexCases.API.Context;
+using CPS.ComplexCases.API.Domain.Request;
+using CPS.ComplexCases.API.Extensions;
+using CPS.ComplexCases.API.Validators.Requests;
+using CPS.ComplexCases.Common.Helpers;
+using CPS.ComplexCases.Common.Models.Requests;
+using CPS.ComplexCases.Common.Attributes;
+using CPS.ComplexCases.Common.Services;
+using CPS.ComplexCases.API.Services;
+>>>>>>> Stashed changes
 
 namespace CPS.ComplexCases.API.Functions.Transfer;
 
-public class GetFilesForTransfer(IFileTransferClient transferClient, ILogger<GetFilesForTransfer> logger, IRequestValidator requestValidator, ISecurityGroupMetadataService securityGroupMetadataService)
+public class GetFilesForTransfer(IFileTransferClient transferClient, ILogger<GetFilesForTransfer> logger, IRequestValidator requestValidator, IUserBucketAccessService userBucketAccessService, ICaseMetadataService caseMetadataService)
 {
     private readonly IFileTransferClient _transferClient = transferClient;
     private readonly ILogger<GetFilesForTransfer> _logger = logger;
     private readonly IRequestValidator _requestValidator = requestValidator;
-    private readonly ISecurityGroupMetadataService _securityGroupMetadataService = securityGroupMetadataService;
+    private readonly IUserBucketAccessService _userBucketAccessService = userBucketAccessService;
+    private readonly ICaseMetadataService _caseMetadataService = caseMetadataService;
 
     [Function(nameof(GetFilesForTransfer))]
     [OpenApiOperation(operationId: nameof(GetFilesForTransfer), tags: ["FileTransfer"], Description = "Gets the complete list of files to be transferred from the source storage.")]
@@ -49,7 +64,10 @@ public class GetFilesForTransfer(IFileTransferClient transferClient, ILogger<Get
             return new BadRequestObjectResult(request.ValidationErrors);
         }
 
-        var securityGroups = await _securityGroupMetadataService.GetUserSecurityGroupsAsync(context.BearerToken);
+        var caseMetadata = await _caseMetadataService.GetCaseMetadataForCaseIdAsync(request.Value.CaseId);
+
+        var bucket = await _userBucketAccessService.ResolveBucketAsync(
+            context.BearerToken, caseMetadata?.NetappBucketName, null);
 
         var listFilesForTransferRequest = new ListFilesForTransferRequest
         {
@@ -61,7 +79,7 @@ public class GetFilesForTransfer(IFileTransferClient transferClient, ILogger<Get
             WorkspaceId = request.Value.WorkspaceId,
             Username = context.Username,
             BearerToken = context.BearerToken,
-            BucketName = securityGroups.First().BucketName,
+            BucketName = bucket.BucketName,
             SourceRootFolderPath = request.Value.SourceRootFolderPath,
             SourcePaths = request.Value.SourcePaths.Select(path => new SelectedSourcePath
             {

--- a/backend/CPS.ComplexCases.API/Functions/Transfer/InitiateTransfer.cs
+++ b/backend/CPS.ComplexCases.API/Functions/Transfer/InitiateTransfer.cs
@@ -16,15 +16,22 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+<<<<<<< Updated upstream
+=======
+using CPS.ComplexCases.Common.Attributes;
+using CPS.ComplexCases.Common.Services;
+using CPS.ComplexCases.API.Services;
+>>>>>>> Stashed changes
 
 namespace CPS.ComplexCases.API.Functions.Transfer;
 
-public class InitiateTransfer(ILogger<InitiateTransfer> logger, IFileTransferClient transferClient, IRequestValidator requestValidator, ISecurityGroupMetadataService securityGroupMetadataService)
+public class InitiateTransfer(ILogger<InitiateTransfer> logger, IFileTransferClient transferClient, IRequestValidator requestValidator, IUserBucketAccessService userBucketAccessService, ICaseMetadataService caseMetadataService)
 {
     private readonly ILogger<InitiateTransfer> _logger = logger;
     private readonly IFileTransferClient _transferClient = transferClient;
     private readonly IRequestValidator _requestValidator = requestValidator;
-    private readonly ISecurityGroupMetadataService _securityGroupMetadataService = securityGroupMetadataService;
+    private readonly IUserBucketAccessService _userBucketAccessService = userBucketAccessService;
+    private readonly ICaseMetadataService _caseMetadataService = caseMetadataService;
 
     [Function(nameof(InitiateTransfer))]
     [OpenApiOperation(operationId: nameof(Run), tags: ["FileTransfer"], Description = "Initiate a file transfer.")]
@@ -52,7 +59,11 @@ public class InitiateTransfer(ILogger<InitiateTransfer> logger, IFileTransferCli
             return new BadRequestObjectResult(transferRequest.ValidationErrors);
         }
 
-        var securityGroups = await _securityGroupMetadataService.GetUserSecurityGroupsAsync(context.BearerToken);
+        var caseMetadata = await _caseMetadataService.GetCaseMetadataForCaseIdAsync(transferRequest.Value.CaseId);
+
+        // Snapshotted onto the transfer so in-flight work is unaffected by later bucket changes.
+        var bucket = await _userBucketAccessService.ResolveBucketAsync(
+            context.BearerToken, caseMetadata?.NetappBucketName, null);
 
         var request = new TransferRequest
         {
@@ -71,7 +82,7 @@ public class InitiateTransfer(ILogger<InitiateTransfer> logger, IFileTransferCli
                 CaseId = transferRequest.Value.CaseId,
                 WorkspaceId = transferRequest.Value.WorkspaceId,
                 BearerToken = context.BearerToken,
-                BucketName = securityGroups.First().BucketName
+                BucketName = bucket.BucketName
             },
             TransferDirection = transferRequest.Value.TransferDirection,
             SourceRootFolderPath = transferRequest.Value.SourceRootFolderPath

--- a/backend/CPS.ComplexCases.API/Program.cs
+++ b/backend/CPS.ComplexCases.API/Program.cs
@@ -228,6 +228,7 @@ var host = new HostBuilder()
         services.AddSingleton<IOpenApiConfigurationOptions, OpenApiConfigurationOptions>();
         services.AddSingleton<IRequestValidator, RequestValidator>();
         services.AddSingleton<ISecurityGroupMetadataService, SecurityGroupMetadataService>();
+        services.AddSingleton<IUserBucketAccessService, UserBucketAccessService>();
 
         services.AddSingleton<BlobServiceClient>(provider =>
         {

--- a/backend/CPS.ComplexCases.API/Services/IUserBucketAccessService.cs
+++ b/backend/CPS.ComplexCases.API/Services/IUserBucketAccessService.cs
@@ -1,0 +1,17 @@
+using CPS.ComplexCases.API.Domain.Models;
+
+namespace CPS.ComplexCases.API.Services;
+
+public interface IUserBucketAccessService
+{
+    Task<IReadOnlyList<SecurityGroup>> GetEntitledBucketsAsync(string bearerToken);
+
+    Task<SecurityGroup> EnsureBucketAllowedAsync(string bearerToken, string bucketName);
+
+    /// <summary>
+    /// Resolves the bucket to work against, preferring the value persisted on the case, then any
+    /// bucket supplied by the caller. Both are validated against the user's entitlements. When
+    /// neither is available the first entitlement is used, preserving pre-existing behaviour.
+    /// </summary>
+    Task<SecurityGroup> ResolveBucketAsync(string bearerToken, string? persistedBucketName, string? requestedBucketName);
+}

--- a/backend/CPS.ComplexCases.API/Services/UserBucketAccessService.cs
+++ b/backend/CPS.ComplexCases.API/Services/UserBucketAccessService.cs
@@ -1,0 +1,65 @@
+using CPS.ComplexCases.API.Domain.Models;
+using CPS.ComplexCases.API.Exceptions;
+using Microsoft.Extensions.Logging;
+
+namespace CPS.ComplexCases.API.Services;
+
+public class UserBucketAccessService(
+    ILogger<UserBucketAccessService> logger,
+    ISecurityGroupMetadataService securityGroupMetadataService) : IUserBucketAccessService
+{
+    private readonly ILogger<UserBucketAccessService> _logger = logger;
+    private readonly ISecurityGroupMetadataService _securityGroupMetadataService = securityGroupMetadataService;
+
+    public async Task<IReadOnlyList<SecurityGroup>> GetEntitledBucketsAsync(string bearerToken)
+    {
+        // Throws MissingSecurityGroupException when the user matches no mapping, which the
+        // exception middleware surfaces as a 403.
+        return await _securityGroupMetadataService.GetUserSecurityGroupsAsync(bearerToken);
+    }
+
+    public async Task<SecurityGroup> EnsureBucketAllowedAsync(string bearerToken, string bucketName)
+    {
+        var entitledBuckets = await GetEntitledBucketsAsync(bearerToken);
+
+        return FindEntitledBucket(entitledBuckets, bucketName)
+            ?? throw BucketNotAllowed(bucketName);
+    }
+
+    public async Task<SecurityGroup> ResolveBucketAsync(string bearerToken, string? persistedBucketName, string? requestedBucketName)
+    {
+        var entitledBuckets = await GetEntitledBucketsAsync(bearerToken);
+
+        if (!string.IsNullOrEmpty(persistedBucketName))
+        {
+            return FindEntitledBucket(entitledBuckets, persistedBucketName)
+                ?? throw BucketNotAllowed(persistedBucketName);
+        }
+
+        if (!string.IsNullOrEmpty(requestedBucketName))
+        {
+            return FindEntitledBucket(entitledBuckets, requestedBucketName)
+                ?? throw BucketNotAllowed(requestedBucketName);
+        }
+
+        var fallback = entitledBuckets[0];
+
+        if (entitledBuckets.Count > 1)
+        {
+            _logger.LogWarning(
+                "No bucket was persisted or requested and the user is entitled to {BucketCount} buckets. Defaulting to {BucketName}.",
+                entitledBuckets.Count, fallback.BucketName);
+        }
+
+        return fallback;
+    }
+
+    private static SecurityGroup? FindEntitledBucket(IReadOnlyList<SecurityGroup> entitledBuckets, string bucketName) =>
+        entitledBuckets.FirstOrDefault(x => string.Equals(x.BucketName, bucketName, StringComparison.OrdinalIgnoreCase));
+
+    private MissingSecurityGroupException BucketNotAllowed(string bucketName)
+    {
+        _logger.LogWarning("User is not entitled to bucket {BucketName}.", bucketName);
+        return new MissingSecurityGroupException($"User is not entitled to bucket '{bucketName}'.");
+    }
+}

--- a/backend/CPS.ComplexCases.Common.Tests/Unit/CaseMetadataServiceTests.cs
+++ b/backend/CPS.ComplexCases.Common.Tests/Unit/CaseMetadataServiceTests.cs
@@ -712,6 +712,144 @@ public class CaseMetadataServiceTests
     }
 
     [Fact]
+    public async Task ClearNetAppFolderPathAsync_WhenSuccessful_AlsoClearsBucketName()
+    {
+        // Arrange
+        var caseId = _fixture.Create<int>();
+        var existingMetadata = new CaseMetadata
+        {
+            CaseId = caseId,
+            ActiveTransferId = null,
+            NetappFolderPath = "/existing/netapp/path",
+            NetappBucketName = "manchester-bucket"
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetByCaseIdAsync(caseId))
+            .ReturnsAsync(existingMetadata);
+
+        _repositoryMock
+            .Setup(r => r.UpdateAsync(It.IsAny<CaseMetadata>()))
+            .ReturnsAsync(existingMetadata);
+
+        // Act
+        await _service.ClearNetAppFolderPathAsync(caseId);
+
+        // Assert
+        _repositoryMock.Verify(
+            r => r.UpdateAsync(It.Is<CaseMetadata>(m =>
+                m.CaseId == caseId &&
+                m.NetappFolderPath == null &&
+                m.NetappBucketName == null)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateNetAppConnectionAsync_WhenNoMetadataExists_PersistsBucketName()
+    {
+        // Arrange
+        var caseId = _fixture.Create<int>();
+        var dto = new CreateNetAppConnectionDto
+        {
+            CaseId = caseId,
+            NetAppFolderPath = "/netapp/path",
+            OperationName = _fixture.Create<string>(),
+            BucketName = "manchester-bucket"
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetByCaseIdAsync(caseId))
+            .ReturnsAsync((CaseMetadata?)null);
+
+        // Act
+        await _service.CreateNetAppConnectionAsync(dto);
+
+        // Assert
+        _repositoryMock.Verify(
+            r => r.AddAsync(It.Is<CaseMetadata>(m =>
+                m.CaseId == caseId &&
+                m.NetappFolderPath == "/netapp/path" &&
+                m.NetappBucketName == "manchester-bucket")),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateNetAppConnectionAsync_WhenMetadataExists_UpdatesBucketName()
+    {
+        // Arrange
+        var caseId = _fixture.Create<int>();
+        var existingMetadata = new CaseMetadata
+        {
+            CaseId = caseId,
+            NetappFolderPath = "/old/path",
+            NetappBucketName = "york-bucket"
+        };
+
+        var dto = new CreateNetAppConnectionDto
+        {
+            CaseId = caseId,
+            NetAppFolderPath = "/netapp/path",
+            OperationName = _fixture.Create<string>(),
+            BucketName = "manchester-bucket"
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetByCaseIdAsync(caseId))
+            .ReturnsAsync(existingMetadata);
+
+        _repositoryMock
+            .Setup(r => r.UpdateAsync(It.IsAny<CaseMetadata>()))
+            .ReturnsAsync(existingMetadata);
+
+        // Act
+        await _service.CreateNetAppConnectionAsync(dto);
+
+        // Assert
+        _repositoryMock.Verify(
+            r => r.UpdateAsync(It.Is<CaseMetadata>(m =>
+                m.NetappFolderPath == "/netapp/path" &&
+                m.NetappBucketName == "manchester-bucket")),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateNetAppConnectionAsync_WhenNoBucketSupplied_LeavesExistingBucketIntact()
+    {
+        // Arrange
+        var caseId = _fixture.Create<int>();
+        var existingMetadata = new CaseMetadata
+        {
+            CaseId = caseId,
+            NetappFolderPath = "/old/path",
+            NetappBucketName = "york-bucket"
+        };
+
+        var dto = new CreateNetAppConnectionDto
+        {
+            CaseId = caseId,
+            NetAppFolderPath = "/netapp/path",
+            OperationName = _fixture.Create<string>(),
+            BucketName = null
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetByCaseIdAsync(caseId))
+            .ReturnsAsync(existingMetadata);
+
+        _repositoryMock
+            .Setup(r => r.UpdateAsync(It.IsAny<CaseMetadata>()))
+            .ReturnsAsync(existingMetadata);
+
+        // Act
+        await _service.CreateNetAppConnectionAsync(dto);
+
+        // Assert
+        _repositoryMock.Verify(
+            r => r.UpdateAsync(It.Is<CaseMetadata>(m => m.NetappBucketName == "york-bucket")),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task ClearNetAppFolderPathAsync_WhenRepositoryThrowsException_LogsAndRethrows()
     {
         // Arrange

--- a/backend/CPS.ComplexCases.Common/Services/CaseMetadataService.cs
+++ b/backend/CPS.ComplexCases.Common/Services/CaseMetadataService.cs
@@ -25,6 +25,7 @@ public class CaseMetadataService : ICaseMetadataService
         {
             var existingMetadata = await _caseMetadataRepository.GetByCaseIdAsync(createEgressConnectionDto.CaseId);
 
+<<<<<<< Updated upstream
             if (existingMetadata != null)
             {
                 existingMetadata.EgressWorkspaceId = createEgressConnectionDto.EgressWorkspaceId;
@@ -49,6 +50,40 @@ public class CaseMetadataService : ICaseMetadataService
             _logger.LogError(ex, "Error creating Egress connection for case {CaseId}", createEgressConnectionDto.CaseId);
             throw;
         }
+=======
+  public async Task CreateNetAppConnectionAsync(CreateNetAppConnectionDto createNetAppConnectionDto)
+  {
+    _logger.LogInformation("Creating NetApp connection for case {CaseId}", createNetAppConnectionDto.CaseId);
+    try
+    {
+      var existingMetadata = await _caseMetadataRepository.GetByCaseIdAsync(createNetAppConnectionDto.CaseId);
+
+      if (existingMetadata != null)
+      {
+        existingMetadata.NetappFolderPath = createNetAppConnectionDto.NetAppFolderPath;
+
+        // Only overwrite when a bucket was supplied, so callers that do not resolve one
+        // cannot wipe an already-persisted value.
+        if (!string.IsNullOrEmpty(createNetAppConnectionDto.BucketName))
+        {
+          existingMetadata.NetappBucketName = createNetAppConnectionDto.BucketName;
+        }
+
+        await _caseMetadataRepository.UpdateAsync(existingMetadata);
+        return;
+      }
+      else
+      {
+        var newMetadata = new CaseMetadata
+        {
+          CaseId = createNetAppConnectionDto.CaseId,
+          NetappFolderPath = createNetAppConnectionDto.NetAppFolderPath,
+          NetappBucketName = createNetAppConnectionDto.BucketName
+        };
+        await _caseMetadataRepository.AddAsync(newMetadata);
+        return;
+      }
+>>>>>>> Stashed changes
     }
 
     public async Task CreateNetAppConnectionAsync(CreateNetAppConnectionDto createNetAppConnectionDto)
@@ -160,7 +195,48 @@ public class CaseMetadataService : ICaseMetadataService
         }
     }
 
+<<<<<<< Updated upstream
     public async Task<bool> ClearActiveTransferIdAsync(Guid transferId)
+=======
+  public Task<ClearFolderPathResult> ClearNetAppFolderPathAsync(int caseId) =>
+    ClearConnectionAsync(
+      caseId,
+      logContext: "NetApp folder path",
+      getDisplayValue: m => m.NetappFolderPath,
+      getKeyValue: m => m.NetappFolderPath,
+      clearValue: m =>
+      {
+        m.NetappFolderPath = null;
+        m.NetappBucketName = null;
+      },
+      missingValueState: CaseMetadataState.NetAppFolderPathIsNull
+    );
+
+  public Task<ClearFolderPathResult> ClearEgressConnectionAsync(int caseId) =>
+    ClearConnectionAsync(
+      caseId,
+      logContext: "Egress workspace connection",
+      getDisplayValue: m => m.EgressWorkspaceName ?? m.EgressWorkspaceId,
+      getKeyValue: m => m.EgressWorkspaceId,
+      clearValue: m =>
+      {
+        m.EgressWorkspaceId = null;
+        m.EgressWorkspaceName = null;
+      },
+      missingValueState: CaseMetadataState.EgressConnectionIsNull
+    );
+
+  private async Task<ClearFolderPathResult> ClearConnectionAsync(
+    int caseId,
+    string logContext,
+    Func<CaseMetadata, string?> getDisplayValue,
+    Func<CaseMetadata, string?> getKeyValue,
+    Action<CaseMetadata> clearValue,
+    CaseMetadataState missingValueState)
+  {
+    _logger.LogInformation("Clearing {LogContext} for case {CaseId}", logContext, caseId);
+    try
+>>>>>>> Stashed changes
     {
         _logger.LogInformation("Clearing active transfer ID for transfer {TransferId}", transferId);
         try

--- a/backend/CPS.ComplexCases.Data/Configurations/CaseMetadataConfiguration.cs
+++ b/backend/CPS.ComplexCases.Data/Configurations/CaseMetadataConfiguration.cs
@@ -12,10 +12,20 @@ public class CaseMetadataConfiguration : IEntityTypeConfiguration<CaseMetadata>
         builder.ToTable("case_metadata", SchemaNames.Lcc);
         builder.HasKey(x => x.CaseId);
 
+<<<<<<< Updated upstream
         builder.Property(x => x.CaseId).HasColumnName("case_id").IsRequired();
         builder.Property(x => x.EgressWorkspaceName).HasColumnName("egress_workspace_name").HasMaxLength(200);
         builder.Property(x => x.EgressWorkspaceId).HasColumnName("egress_workspace_id").HasMaxLength(200);
         builder.Property(x => x.NetappFolderPath).HasColumnName("netapp_folder_path").HasMaxLength(260);
         builder.Property(x => x.ActiveTransferId).HasColumnName("active_transfer_id");
     }
+=======
+    builder.Property(x => x.CaseId).HasColumnName("case_id").IsRequired();
+    builder.Property(x => x.EgressWorkspaceName).HasColumnName("egress_workspace_name").HasMaxLength(200);
+    builder.Property(x => x.EgressWorkspaceId).HasColumnName("egress_workspace_id").HasMaxLength(200);
+    builder.Property(x => x.NetappFolderPath).HasColumnName("netapp_folder_path").HasMaxLength(260);
+    builder.Property(x => x.NetappBucketName).HasColumnName("netapp_bucket_name").HasMaxLength(200);
+    builder.Property(x => x.ActiveTransferId).HasColumnName("active_transfer_id");
+  }
+>>>>>>> Stashed changes
 }

--- a/backend/CPS.ComplexCases.Data/Entities/CaseMetadata.cs
+++ b/backend/CPS.ComplexCases.Data/Entities/CaseMetadata.cs
@@ -3,9 +3,18 @@ namespace CPS.ComplexCases.Data.Entities;
 
 public class CaseMetadata
 {
+<<<<<<< Updated upstream
     public required int CaseId { get; set; }
     public string? EgressWorkspaceId { get; set; }
     public string? EgressWorkspaceName { get; set; }
     public string? NetappFolderPath { get; set; }
     public Guid? ActiveTransferId { get; set; }
+=======
+  public required int CaseId { get; set; }
+  public string? EgressWorkspaceId { get; set; }
+  public string? EgressWorkspaceName { get; set; }
+  public string? NetappFolderPath { get; set; }
+  public string? NetappBucketName { get; set; }
+  public Guid? ActiveTransferId { get; set; }
+>>>>>>> Stashed changes
 }

--- a/backend/CPS.ComplexCases.Data/Migrations/20260814091004_AddNetappBucketNameToCaseMetadata.Designer.cs
+++ b/backend/CPS.ComplexCases.Data/Migrations/20260814091004_AddNetappBucketNameToCaseMetadata.Designer.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using CPS.ComplexCases.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CPS.ComplexCases.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260814091004_AddNetappBucketNameToCaseMetadata")]
+    partial class AddNetappBucketNameToCaseMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/CPS.ComplexCases.Data/Migrations/20260814091004_AddNetappBucketNameToCaseMetadata.cs
+++ b/backend/CPS.ComplexCases.Data/Migrations/20260814091004_AddNetappBucketNameToCaseMetadata.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CPS.ComplexCases.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNetappBucketNameToCaseMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "netapp_bucket_name",
+                schema: "large_complex_cases",
+                table: "case_metadata",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "netapp_bucket_name",
+                schema: "large_complex_cases",
+                table: "case_metadata");
+        }
+    }
+}

--- a/backend/CPS.ComplexCases.Data/Models/Requests/CreateNetAppConnectionDto.cs
+++ b/backend/CPS.ComplexCases.Data/Models/Requests/CreateNetAppConnectionDto.cs
@@ -10,4 +10,6 @@ public class CreateNetAppConnectionDto
     public required string OperationName { get; set; }
     [JsonPropertyName("folderPath")]
     public required string NetAppFolderPath { get; set; }
+    [JsonPropertyName("bucketName")]
+    public string? BucketName { get; set; }
 }

--- a/backend/CPS.ComplexCases.NetApp/Models/Dto/ProvisionNetAppFoldersDto.cs
+++ b/backend/CPS.ComplexCases.NetApp/Models/Dto/ProvisionNetAppFoldersDto.cs
@@ -6,5 +6,7 @@ namespace CPS.ComplexCases.NetApp.Models.Dto
     {
         [JsonPropertyName("templateFolderPath")]
         public string TemplateFolderPath { get; set; } = null!;
+        [JsonPropertyName("bucketName")]
+        public string? BucketName { get; set; }
     }
 }

--- a/ui-spa/package-lock.json
+++ b/ui-spa/package-lock.json
@@ -65,6 +65,10 @@
         "vite-plugin-istanbul": "^7.1.0",
         "vite-plugin-svgr": "^4.3.0",
         "vitest": "^3.0.6"
+      },
+      "engines": {
+        "node": "24.x",
+        "npm": "11.x"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
# PR checklist

Tick what applies before you raise. Delete anything that doesn't.

## Correctness
- [x] Does what the ticket asks for
- [x] Handles the edge cases (empty, null, zero, large inputs), not just the happy path
- [x] Errors are handled, not swallowed
- [x] New logic has tests, including the failure cases
- [x] Tests assert something real, not just run the code

## Keeping it simple
- [x] Doesn't rebuild something that already exists in the codebase
- [x] No more complex or slower than it needs to be
- [x] No leftover debug logging or commented-out code

## Code Quality
- [x] Pre-commit hooks were run for all commits in this PR

## Easy to miss (a green pipeline won't flag these)
- [x] One logical change, not a pile of unrelated stuff

### If you touched the backend
- [x] Schema changes have a migration, and the Down() doesn't drop anything it shouldn't
- [x] New app settings are wired into the fa-config templates
- [x] Secrets use Key Vault references, not plain text
- [x] New outbound HTTP clients go through the shared resilience handler (AddResiliencePolicyHandler), rather than hand-rolling retries
- [x] New calls to an external service (DDEI, Egress, NetApp) have client tests against a WireMock stub (for the serialisation, auth and error handling) and are covered by the integration tests that run against the real dev services

### If you touched the UI
- [x] Ran the e2e/ suite locally (the PR build only runs the mocked tests; the full suite runs post-merge and gates the deploy)
- [x] API changes are reflected in the MSW handlers in src/mocks and the matching zod schema, so the mocked tests aren't passing against a contract that's gone
- [x] New config or feature flags are wired into the VITE build variables, not just added in code
- [x] Data fetches handle the loading, empty and error states, not just success, and match how the rest of the app already does it
- [x] Ran prettier (npm run prettier:format), since CI lints but doesn't check formatting
- [x] Checked accessibility (keyboard nav, screen reader, sensible labels), since the Lighthouse run is manual and won't flag it for you
