### PR TITLE
CompleteMultipartUploadAsync retry 404s 

### DIFF
--- a/backend/CPS.ComplexCases.API.Integration.Tests/E2E/E2ETransferFlowTests.cs
+++ b/backend/CPS.ComplexCases.API.Integration.Tests/E2E/E2ETransferFlowTests.cs
@@ -123,10 +123,9 @@ public class E2ETransferFlowTests : IClassFixture<IntegrationTestFixture>, IAsyn
 
         var netAppDestinationPath = $"{_netAppTestFolderPrefix}/{testFileName}";
 
-        // In production (TransferFile.cs) the orchestrator retries the entire activity when
-        // CompleteMultipartUpload returns a transient 500, because the error also internally aborts
-        // the multipart upload and invalidates the upload ID. We mirror that here by restarting the
-        // full flow (initiate → upload parts → complete) on each attempt.
+        // CompleteMultipartUploadAsync already retries InternalError (including NetApp's HTTP 404
+        // InternalError) against the same uploadId. If those retries are exhausted the upload ID
+        // may no longer be valid, so this test restarts initiate → upload parts → complete.
         var chunks = TestDataHelper.SplitIntoChunks(testContent, partSize).ToList();
         string? completedETag = null;
         for (var attempt = 1; attempt <= 3; attempt++)
@@ -166,8 +165,8 @@ public class E2ETransferFlowTests : IClassFixture<IntegrationTestFixture>, IAsyn
             }
             catch (AmazonS3Exception) when (attempt < 3)
             {
-                // StorageGRID aborted the upload alongside the internal error;
-                // the upload ID is now invalid so the full flow must be restarted.
+                // Complete retries were exhausted; restart the full multipart flow
+                // in case the upload ID is no longer valid.
             }
         }
 
@@ -977,8 +976,8 @@ public class E2ETransferFlowTests : IClassFixture<IntegrationTestFixture>, IAsyn
             }
             catch (AmazonS3Exception) when (attempt < 3)
             {
-                // StorageGRID aborted the upload alongside the internal error;
-                // the upload ID is now invalid so the full flow must be restarted.
+                // Complete retries were exhausted; restart the full multipart flow
+                // in case the upload ID is no longer valid.
             }
         }
 

--- a/backend/CPS.ComplexCases.API.Integration.Tests/NetApp/NetAppClientTests.cs
+++ b/backend/CPS.ComplexCases.API.Integration.Tests/NetApp/NetAppClientTests.cs
@@ -282,10 +282,9 @@ public class NetAppClientTests : IClassFixture<IntegrationTestFixture>, IAsyncLi
         new Random().NextBytes(part1Data);
         new Random().NextBytes(part2Data);
 
-        // In production (TransferFile.cs) the orchestrator retries the entire activity when
-        // CompleteMultipartUpload returns a transient 500, because the error also internally aborts
-        // the multipart upload and invalidates the upload ID. We mirror that here by restarting the
-        // full flow (initiate → upload parts → complete) on each attempt.
+        // CompleteMultipartUploadAsync already retries InternalError (including NetApp's HTTP 404
+        // InternalError) against the same uploadId. If those retries are exhausted the upload ID
+        // may no longer be valid, so this test restarts initiate → upload parts → complete.
         string? completedETag = null;
         for (var attempt = 1; attempt <= 3; attempt++)
         {
@@ -330,8 +329,8 @@ public class NetAppClientTests : IClassFixture<IntegrationTestFixture>, IAsyncLi
             }
             catch (AmazonS3Exception) when (attempt < 3)
             {
-                // StorageGRID aborted the upload alongside the internal error;
-                // the upload ID is now invalid so the full flow must be restarted.
+                // Complete retries were exhausted; restart the full multipart flow
+                // in case the upload ID is no longer valid.
             }
         }
 

--- a/backend/CPS.ComplexCases.API.Integration.Tests/NetApp/NetAppStorageClientTests.cs
+++ b/backend/CPS.ComplexCases.API.Integration.Tests/NetApp/NetAppStorageClientTests.cs
@@ -207,10 +207,9 @@ public class NetAppStorageClientTests : IClassFixture<IntegrationTestFixture>, I
         var sourcePath = $"multipart-storage-{Guid.NewGuid():N}.bin";
         var totalSize = part1Data.Length + part2Data.Length;
 
-        // In production (TransferFile.cs) the orchestrator retries the entire activity when
-        // CompleteMultipartUpload returns a transient 500, because the error also internally aborts
-        // the multipart upload and invalidates the upload ID. We mirror that here by restarting the
-        // full flow (initiate → upload parts → complete) on each attempt.
+        // CompleteMultipartUploadAsync already retries InternalError (including NetApp's HTTP 404
+        // InternalError) against the same uploadId. If those retries are exhausted the upload ID
+        // may no longer be valid, so this test restarts initiate → upload parts → complete.
         UploadSession? completedSession = null;
         for (var attempt = 1; attempt <= 3; attempt++)
         {
@@ -258,8 +257,8 @@ public class NetAppStorageClientTests : IClassFixture<IntegrationTestFixture>, I
             }
             catch (AmazonS3Exception) when (attempt < 3)
             {
-                // StorageGRID aborted the upload alongside the internal error;
-                // the upload ID is now invalid so the full flow must be restarted.
+                // Complete retries were exhausted; restart the full multipart flow
+                // in case the upload ID is no longer valid.
             }
         }
 

--- a/backend/CPS.ComplexCases.NetApp.Tests/Unit/NetAppClientTests.cs
+++ b/backend/CPS.ComplexCases.NetApp.Tests/Unit/NetAppClientTests.cs
@@ -974,6 +974,84 @@ namespace CPS.ComplexCases.NetApp.Tests.Unit
         }
 
         [Fact]
+        public async Task CompleteMultipartUploadAsync_RetriesOn404InternalError_AndSucceeds()
+        {
+            var arg = new CompleteMultipartUploadArg
+            {
+                BearerToken = BearerToken,
+                ObjectKey = "file.txt",
+                BucketName = "bucket",
+                UploadId = "uploadid",
+                CompletedParts = []
+            };
+            var expectedResponse = new CompleteMultipartUploadResponse();
+
+            var callCount = 0;
+            _amazonS3Mock
+                .Setup(s => s.CompleteMultipartUploadAsync(It.IsAny<CompleteMultipartUploadRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    callCount++;
+                    if (callCount == 1)
+                    {
+                        throw new AmazonS3Exception("We encountered an internal error. Please try again.")
+                        {
+                            StatusCode = HttpStatusCode.NotFound,
+                            ErrorCode = S3ErrorCodes.InternalError
+                        };
+                    }
+
+                    return expectedResponse;
+                });
+
+            var result = await _client.CompleteMultipartUploadAsync(arg);
+
+            Assert.Equal(expectedResponse, result);
+            _amazonS3Mock.Verify(
+                s => s.CompleteMultipartUploadAsync(It.IsAny<CompleteMultipartUploadRequest>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Exactly(2));
+            _loggerMock.Verify(
+                l => l.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) =>
+                        v != null && v!.ToString()!.Contains("CompleteMultipartUpload retry attempt")),
+                    It.IsAny<AmazonS3Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task CompleteMultipartUploadAsync_DoesNotRetryOnNoSuchUpload404()
+        {
+            var arg = new CompleteMultipartUploadArg
+            {
+                BearerToken = BearerToken,
+                ObjectKey = "file.txt",
+                BucketName = "bucket",
+                UploadId = "uploadid",
+                CompletedParts = []
+            };
+
+            _amazonS3Mock
+                .Setup(s => s.CompleteMultipartUploadAsync(It.IsAny<CompleteMultipartUploadRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new AmazonS3Exception("The specified upload does not exist.")
+                {
+                    StatusCode = HttpStatusCode.NotFound,
+                    ErrorCode = S3ErrorCodes.NoSuchUpload
+                });
+
+            await Assert.ThrowsAsync<AmazonS3Exception>(() => _client.CompleteMultipartUploadAsync(arg));
+            _amazonS3Mock.Verify(
+                s => s.CompleteMultipartUploadAsync(It.IsAny<CompleteMultipartUploadRequest>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
         public async Task DoesObjectExistAsync_ReturnsTrue_OnSuccess()
         {
             var arg = new GetObjectArg { BearerToken = BearerToken, ObjectKey = "file.txt", BucketName = "bucket" };

--- a/backend/CPS.ComplexCases.NetApp/Client/NetAppClient.cs
+++ b/backend/CPS.ComplexCases.NetApp/Client/NetAppClient.cs
@@ -423,8 +423,8 @@ public class NetAppClient(
         catch (AmazonS3Exception ex)
         {
             _logger.LogError(ex,
-                "Failed to complete multipart upload {UploadId} for file {ObjectKey} after all retry attempts.",
-                arg.UploadId, arg.ObjectKey);
+                "Failed to complete multipart upload {UploadId} for file {ObjectKey} after all retry attempts. StatusCode={StatusCode}, ErrorCode={ErrorCode}",
+                arg.UploadId, arg.ObjectKey, ex.StatusCode, ex.ErrorCode);
             throw;
         }
     }
@@ -1052,18 +1052,18 @@ public class NetAppClient(
                 BackoffType = DelayBackoffType.Exponential,
                 UseJitter = true,
                 ShouldHandle = new PredicateBuilder<CompleteMultipartUploadResponse?>()
-                    .Handle<AmazonS3Exception>(ex => (int)ex.StatusCode >= 500
-                        || ex.StatusCode == HttpStatusCode.RequestTimeout
-                        || IsCredentialError(ex)),
+                    .Handle<AmazonS3Exception>(IsRetryableCompleteMultipartUploadError),
                 OnRetry = async args =>
                 {
+                    var s3Exception = args.Outcome.Exception as AmazonS3Exception;
                     _logger.LogWarning(args.Outcome.Exception,
-                        "CompleteMultipartUpload retry attempt {RetryCount} for upload {UploadId} ({ObjectKey}). Waiting {DelayMs}ms.",
-                        args.AttemptNumber + 1, uploadId, objectKey, args.RetryDelay.TotalMilliseconds);
+                        "CompleteMultipartUpload retry attempt {RetryCount} for upload {UploadId} ({ObjectKey}). StatusCode={StatusCode}, ErrorCode={ErrorCode}. Waiting {DelayMs}ms.",
+                        args.AttemptNumber + 1, uploadId, objectKey, s3Exception?.StatusCode, s3Exception?.ErrorCode,
+                        args.RetryDelay.TotalMilliseconds);
 
                     // Force credential regeneration on retry so the next attempt
                     // gets fresh keys from NetApp instead of reusing the dead cache.
-                    if (args.Outcome.Exception is AmazonS3Exception s3Ex && IsCredentialError(s3Ex))
+                    if (s3Exception != null && IsCredentialError(s3Exception))
                     {
                         await _s3ClientFactory.InvalidateClientAsync();
                     }
@@ -1071,6 +1071,20 @@ public class NetAppClient(
             })
             .Build();
     }
+
+    // Retry CompleteMultipartUpload against the existing uploadId rather than restarting the
+    // whole multipart upload. Amazon S3 documents InternalError as retryable; NetApp's S3 API
+    // intermittently returns that error as HTTP 404 after every part has already uploaded.
+    // A genuine NoSuchUpload (upload completed or aborted) is not retried here.
+    private static bool IsRetryableCompleteMultipartUploadError(AmazonS3Exception ex) =>
+        (int)ex.StatusCode >= 500
+        || ex.StatusCode == HttpStatusCode.RequestTimeout
+        || IsCredentialError(ex)
+        || IsInternalError(ex);
+
+    private static bool IsInternalError(AmazonS3Exception ex) =>
+        string.Equals(ex.ErrorCode, S3ErrorCodes.InternalError, StringComparison.OrdinalIgnoreCase)
+        || ex.Message.Contains("We encountered an internal error", StringComparison.OrdinalIgnoreCase);
 
     private static bool IsCredentialError(AmazonS3Exception ex)
         => ex.ErrorCode is S3ErrorCodes.InvalidAccessKeyId or S3ErrorCodes.ExpiredToken

--- a/backend/CPS.ComplexCases.NetApp/Constants/S3ErrorCodes.cs
+++ b/backend/CPS.ComplexCases.NetApp/Constants/S3ErrorCodes.cs
@@ -6,4 +6,6 @@ public static class S3ErrorCodes
     public const string InvalidAccessKeyId = "InvalidAccessKeyId";
     public const string ExpiredToken = "ExpiredToken";
     public const string InvalidClientTokenId = "InvalidClientTokenId";
+    public const string InternalError = "InternalError";
+    public const string NoSuchUpload = "NoSuchUpload";
 }


### PR DESCRIPTION
# PR checklist

Tick what applies before you raise. Delete anything that doesn't.

## Correctness
- [x] Does what the ticket asks for
- [x] Handles the edge cases (empty, null, zero, large inputs), not just the happy path
- [x] Errors are handled, not swallowed
- [x] New logic has tests, including the failure cases
- [x] Tests assert something real, not just run the code

## Keeping it simple
- [x] Doesn't rebuild something that already exists in the codebase
- [x] No more complex or slower than it needs to be
- [x] No leftover debug logging or commented-out code

## Code Quality
- [x] Pre-commit hooks were run for all commits in this PR

## Easy to miss (a green pipeline won't flag these)
- [x] One logical change, not a pile of unrelated stuff

### If you touched the backend
- [x] Schema changes have a migration, and the Down() doesn't drop anything it shouldn't
- [x] New app settings are wired into the fa-config templates
- [x] Secrets use Key Vault references, not plain text
- [x] New outbound HTTP clients go through the shared resilience handler (AddResiliencePolicyHandler), rather than hand-rolling retries
- [x] New calls to an external service (DDEI, Egress, NetApp) have client tests against a WireMock stub (for the serialisation, auth and error handling) and are covered by the integration tests that run against the real dev services

### If you touched the UI
- [ ] Ran the e2e/ suite locally (the PR build only runs the mocked tests; the full suite runs post-merge and gates the deploy)
- [ ] API changes are reflected in the MSW handlers in src/mocks and the matching zod schema, so the mocked tests aren't passing against a contract that's gone
- [ ] New config or feature flags are wired into the VITE build variables, not just added in code
- [ ] Data fetches handle the loading, empty and error states, not just success, and match how the rest of the app already does it
- [ ] Ran prettier (npm run prettier:format), since CI lints but doesn't check formatting
- [ ] Checked accessibility (keyboard nav, screen reader, sensible labels), since the Lighthouse run is manual and won't flag it for you
