### PR TITLE
remove commented-out code

### DIFF
--- a/devops-pipelines/move-soak-test.yml
+++ b/devops-pipelines/move-soak-test.yml
@@ -90,7 +90,7 @@ jobs:
         condition: succeededOrFailed()
 
   - job: cleanupTestFiles
-    displayName: "Cleanup Test Files from Egress and Shared Drive"
+    displayName: "Cleanup Test Files from Shared Drive"
     dependsOn: runMoveSoakTest
     condition: succeededOrFailed()
     pool: ${{ parameters.agentPool }}
@@ -119,16 +119,3 @@ jobs:
             -BaseUrl $(LccApiBaseUrl)
             -ExcludePatterns "lcc-e2e-fixture-source"
             -Force
-
-      # # Egress cleanup disabled to investigate failed post-move delete from source
-      # - task: PowerShell@2
-      #   displayName: "Clear ExistingCaseAutomation Egress folder"
-      #   condition: succeededOrFailed()
-      #   inputs:
-      #     filePath: "$(System.DefaultWorkingDirectory)/devops-pipelines/scripts/test-automation-cleanup/Clear-EgressFolder.ps1"
-      #     arguments: >
-      #       -BaseUrl "$(EgressOptionsUrl)"
-      #       -ServiceAccountAuth "$(EgressServiceAccountAuth)"
-      #       -WorkspaceId "$(E2eEgressWorkspaceId)"
-      #       -FolderName "1. ABEs for Transcript"
-      #       -Force


### PR DESCRIPTION
Remove commented out cleanup step.

The soak test pipeline originally included a step to clean up the Egress folder after files had been moved. This step was later commented out to support investigation of an issue where some files remained in Egress following the move operation.
Although this issue has not recurred during subsequent testing, retaining any files left behind after a failed run could provide valuable evidence for investigating future occurrences of this issue, or other move-related failures.

As the move operation is expected to remove all files from Egress during a successful run, the additional cleanup step is unnecessary. 
In failure scenarios, preserving the contents of the source folder offers greater visibility into the state of the move process and can aid troubleshooting.