### PR TITLE
egress patch retrying

### DIFF
--- a/backend/CPS.ComplexCases.API/Extensions/IServiceCollectionExtension.cs
+++ b/backend/CPS.ComplexCases.API/Extensions/IServiceCollectionExtension.cs
@@ -32,7 +32,7 @@ public static class IServiceCollectionExtension
                 .GetRequiredService<ILoggerFactory>()
                 .CreateLogger("CPS.ComplexCases.API.FileTransfer");
 
-            // Shared helper keeps POST/PUT out of status-code retries. Circuit breaker is off —
+            // Shared helper keeps POST/PUT/PATCH out of status-code retries. Circuit breaker is off —
             // FileTransfer only needs the common retry policy, not fail-fast shedding.
             pipeline.AddStandardHttpResilience(new HttpResilienceOptions
             {

--- a/backend/CPS.ComplexCases.Common.Tests/Extensions/ResiliencePipelineExtensionsTests.cs
+++ b/backend/CPS.ComplexCases.Common.Tests/Extensions/ResiliencePipelineExtensionsTests.cs
@@ -163,8 +163,11 @@ public class ResiliencePipelineExtensionsTests
         Assert.Equal(3, attempts);
     }
 
-    [Fact]
-    public async Task Retry_DoesNotRetryNonIdempotentMethods()
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    [InlineData("PATCH")]
+    public async Task Retry_DoesNotRetryNonIdempotentMethods(string method)
     {
         var pipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
             .AddStandardHttpResilience(new HttpResilienceOptions
@@ -186,7 +189,7 @@ public class ResiliencePipelineExtensionsTests
         await pipeline.ExecuteAsync(_ =>
         {
             attempts++;
-            var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test");
+            var request = new HttpRequestMessage(new HttpMethod(method), "https://example.test");
             return ValueTask.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError) { RequestMessage = request });
         });
 

--- a/backend/CPS.ComplexCases.Common/Extensions/ResiliencePipelineExtensions.cs
+++ b/backend/CPS.ComplexCases.Common/Extensions/ResiliencePipelineExtensions.cs
@@ -49,7 +49,7 @@ public static class ResiliencePipelineExtensions
                 ShouldHandle = args =>
                 {
                     // Connection failures are retried regardless of method, since there is no response to
-                    // inspect. POST/PUT are only excluded on the status-code path below.
+                    // inspect. POST/PUT/PATCH are only excluded on the status-code path below.
                     if (options.RetryOnConnectionFailure && args.Outcome.Exception is HttpRequestException)
                     {
                         return ValueTask.FromResult(true);
@@ -64,7 +64,7 @@ public static class ResiliencePipelineExtensions
                     var isRetryableStatus = response.StatusCode >= HttpStatusCode.InternalServerError
                 || options.AdditionalRetryableStatusCodes.Contains(response.StatusCode);
 
-                    return ValueTask.FromResult(isRetryableStatus && ExcludesPostAndPut(response));
+                    return ValueTask.FromResult(isRetryableStatus && ExcludesNonIdempotentMethods(response));
                 }
             });
         }
@@ -125,8 +125,9 @@ public static class ResiliencePipelineExtensions
         return pipeline;
     }
 
-    // Retries are only safe for idempotent methods, so POST and PUT are excluded.
-    private static bool ExcludesPostAndPut(HttpResponseMessage response) =>
+    // Retries are only safe for idempotent methods, so POST, PUT, and PATCH are excluded.
+    private static bool ExcludesNonIdempotentMethods(HttpResponseMessage response) =>
         response.RequestMessage?.Method != HttpMethod.Post
-        && response.RequestMessage?.Method != HttpMethod.Put;
+        && response.RequestMessage?.Method != HttpMethod.Put
+        && response.RequestMessage?.Method != HttpMethod.Patch;
 }

--- a/backend/CPS.ComplexCases.Common/Resilience/HttpResilienceOptions.cs
+++ b/backend/CPS.ComplexCases.Common/Resilience/HttpResilienceOptions.cs
@@ -26,7 +26,7 @@ public sealed record HttpResilienceOptions
     public bool RetryOnConnectionFailure { get; init; }
 
     // Status codes (in addition to 5xx) that should be retried, e.g. 404 for MDS or 429 for
-    // rate-limited services. POST/PUT are always excluded because retries are only safe for
+    // rate-limited services. POST/PUT/PATCH are always excluded because retries are only safe for
     // idempotent methods.
     public IReadOnlyCollection<HttpStatusCode> AdditionalRetryableStatusCodes { get; init; } = [];
 }

--- a/backend/CPS.ComplexCases.Egress.Tests/Unit/EgressStorageClientTests.cs
+++ b/backend/CPS.ComplexCases.Egress.Tests/Unit/EgressStorageClientTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
+using Polly.CircuitBreaker;
 
 namespace CPS.ComplexCases.Egress.Tests.Unit;
 
@@ -823,6 +824,92 @@ public class EgressStorageClientTests : IDisposable
     }
 
     [Fact]
+    public async Task UploadChunkAsync_WhenConnectionDropsThenSucceeds_RetriesAndSucceeds()
+    {
+        var uploadId = _fixture.Create<string>();
+        var workspaceId = _fixture.Create<string>();
+        var session = new UploadSession { UploadId = uploadId, WorkspaceId = workspaceId };
+        var chunkData = Encoding.UTF8.GetBytes("chunk");
+        var token = _fixture.Create<string>();
+
+        var client = CreateClientWithChunkRetryOptions(maxAttempts: 3, baseDelaySeconds: 1);
+
+        SetupTokenRequest(token);
+        _requestFactoryMock
+            .Setup(f => f.UploadChunkRequest(It.IsAny<UploadChunkArg>(), It.IsAny<string>()))
+            .Returns(() => new HttpRequestMessage(HttpMethod.Patch, $"{TestUrl}/api/v1/uploads/{uploadId}/"));
+
+        SetupHttpMockSequence(
+            JsonResponse(new GetWorkspaceTokenResponse { Token = token }),
+            new HttpRequestException("Connection reset"),
+            JsonResponse(new { Success = true }));
+
+        var result = await client.UploadChunkAsync(session, 1, chunkData, 0, chunkData.Length - 1, chunkData.Length);
+
+        Assert.NotNull(result);
+        _requestFactoryMock.Verify(
+            f => f.UploadChunkRequest(It.IsAny<UploadChunkArg>(), It.IsAny<string>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task UploadChunkAsync_WhenConnectionAlwaysDrops_ThrowsAfterMaxAttempts()
+    {
+        var uploadId = _fixture.Create<string>();
+        var workspaceId = _fixture.Create<string>();
+        var session = new UploadSession { UploadId = uploadId, WorkspaceId = workspaceId };
+        var chunkData = Encoding.UTF8.GetBytes("chunk");
+        var token = _fixture.Create<string>();
+
+        var client = CreateClientWithChunkRetryOptions(maxAttempts: 2, baseDelaySeconds: 1);
+
+        SetupTokenRequest(token);
+        _requestFactoryMock
+            .Setup(f => f.UploadChunkRequest(It.IsAny<UploadChunkArg>(), It.IsAny<string>()))
+            .Returns(() => new HttpRequestMessage(HttpMethod.Patch, $"{TestUrl}/api/v1/uploads/{uploadId}/"));
+
+        SetupHttpMockSequence(
+            JsonResponse(new GetWorkspaceTokenResponse { Token = token }),
+            new HttpRequestException("Connection reset"),
+            new HttpRequestException("Connection reset"));
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.UploadChunkAsync(session, 1, chunkData, 0, chunkData.Length - 1, chunkData.Length));
+
+        _requestFactoryMock.Verify(
+            f => f.UploadChunkRequest(It.IsAny<UploadChunkArg>(), It.IsAny<string>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task UploadChunkAsync_WhenCircuitIsOpen_DoesNotRetry()
+    {
+        var uploadId = _fixture.Create<string>();
+        var workspaceId = _fixture.Create<string>();
+        var session = new UploadSession { UploadId = uploadId, WorkspaceId = workspaceId };
+        var chunkData = Encoding.UTF8.GetBytes("chunk");
+        var token = _fixture.Create<string>();
+
+        var client = CreateClientWithChunkRetryOptions(maxAttempts: 4, baseDelaySeconds: 1);
+
+        SetupTokenRequest(token);
+        _requestFactoryMock
+            .Setup(f => f.UploadChunkRequest(It.IsAny<UploadChunkArg>(), It.IsAny<string>()))
+            .Returns(() => new HttpRequestMessage(HttpMethod.Patch, $"{TestUrl}/api/v1/uploads/{uploadId}/"));
+
+        SetupHttpMockSequence(
+            JsonResponse(new GetWorkspaceTokenResponse { Token = token }),
+            new BrokenCircuitException());
+
+        await Assert.ThrowsAsync<BrokenCircuitException>(
+            () => client.UploadChunkAsync(session, 1, chunkData, 0, chunkData.Length - 1, chunkData.Length));
+
+        _requestFactoryMock.Verify(
+            f => f.UploadChunkRequest(It.IsAny<UploadChunkArg>(), It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task CreateFolderAsync_CreatesEachMissingSegment()
     {
         // Arrange
@@ -1233,6 +1320,32 @@ public class EgressStorageClientTests : IDisposable
             sequence = sequence.ReturnsAsync(httpResponse);
         }
     }
+
+    private void SetupHttpMockSequence(params object[] outcomes)
+    {
+        var sequence = _httpMessageHandlerMock
+            .Protected()
+            .SetupSequence<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>());
+
+        foreach (var outcome in outcomes)
+        {
+            sequence = outcome switch
+            {
+                Exception ex => sequence.ThrowsAsync(ex),
+                HttpResponseMessage response => sequence.ReturnsAsync(response),
+                _ => throw new ArgumentException($"Unexpected mock outcome type {outcome.GetType()}"),
+            };
+        }
+    }
+
+    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode statusCode = HttpStatusCode.OK) =>
+        new(statusCode)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(body))
+        };
 
     /// <summary>
     /// Invokes the private ConstructRelativePath method using reflection for testing.

--- a/backend/CPS.ComplexCases.Egress/Client/EgressStorageClient.cs
+++ b/backend/CPS.ComplexCases.Egress/Client/EgressStorageClient.cs
@@ -166,11 +166,13 @@ public class EgressStorageClient(
             $"Chunk {chunkNumber} upload for upload {session.UploadId} failed after {maxAttempts} attempts.");
     }
 
-    // Egress chunk PATCH's fail intermittently with 5xx/429 under load, and a slow link can trip the
-    // per-chunk timeout. All of these are worth a bounded retry before failing the whole file.
+    // Egress chunk PATCHes fail intermittently with 5xx/429 under load, a dropped connection has no
+    // status code, and a slow link can trip the per-chunk timeout. All of these are worth a bounded
+    // retry before failing the whole file. BrokenCircuitException is not retried: fail-fast while the
+    // circuit is open, and let the transfer orchestrator resume the file after the break.
     private static bool IsRetryableChunkError(Exception ex) =>
         (ex is HttpRequestException httpEx
-            && ((int?)httpEx.StatusCode >= 500 || httpEx.StatusCode == HttpStatusCode.TooManyRequests))
+            && httpEx.StatusCode is null or >= HttpStatusCode.InternalServerError or HttpStatusCode.TooManyRequests)
         || ex is OperationCanceledException
         || ex is TimeoutException;
 


### PR DESCRIPTION
# PR checklist

Tick what applies before you raise. Delete anything that doesn't.

## Correctness
- [x] Does what the ticket asks for
- [x] Handles the edge cases (empty, null, zero, large inputs), not just the happy path
- [x] Errors are handled, not swallowed
- [x] New logic has tests, including the failure cases
- [x] Tests assert something real, not just run the code

## Keeping it simple
- [x] Doesn't rebuild something that already exists in the codebase
- [x] No more complex or slower than it needs to be
- [x] No leftover debug logging or commented-out code

## Code Quality
- [x] Pre-commit hooks were run for all commits in this PR

## Easy to miss (a green pipeline won't flag these)
- [x] One logical change, not a pile of unrelated stuff

### If you touched the backend
- [x] Schema changes have a migration, and the Down() doesn't drop anything it shouldn't
- [x] New app settings are wired into the fa-config templates
- [x] Secrets use Key Vault references, not plain text
- [x] New outbound HTTP clients go through the shared resilience handler (AddResiliencePolicyHandler), rather than hand-rolling retries
- [x] New calls to an external service (DDEI, Egress, NetApp) have client tests against a WireMock stub (for the serialisation, auth and error handling) and are covered by the integration tests that run against the real dev services
