### PR TITLE
issue with shared drive multiple connections

### DIFF
--- a/backend/CPS.ComplexCases.API.Tests/Unit/Services/CaseEnrichmentServiceTests.cs
+++ b/backend/CPS.ComplexCases.API.Tests/Unit/Services/CaseEnrichmentServiceTests.cs
@@ -523,6 +523,69 @@ public class CaseEnrichmentServiceTests
     }
 
     [Fact]
+    public async Task EnrichNetAppFoldersWithMetadataAsync_WhenFolderPathLinkedToMultipleCases_EnrichesWithLowestCaseIdAndLogsWarning()
+    {
+        // Arrange
+        var folders = CreateSampleNetAppFolders(2);
+        var folderPaths = folders.Data.FolderData
+            .Where(d => d.Path != null)
+            .Select(d => d.Path!)
+            .ToList();
+
+        var duplicatedPath = folderPaths.First();
+        var metadata = new List<CaseMetadata>
+        {
+            new CaseMetadata { CaseId = 77, NetappFolderPath = duplicatedPath },
+            new CaseMetadata { CaseId = 42, NetappFolderPath = duplicatedPath },
+            new CaseMetadata { CaseId = 99, NetappFolderPath = folderPaths.Last() }
+        };
+
+        _caseMetadataServiceMock
+            .Setup(s => s.GetCaseMetadataForNetAppFolderPathsAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(metadata);
+
+        // Act
+        var result = await _service.EnrichNetAppFoldersWithMetadataAsync(folders);
+
+        // Assert
+        Assert.Equal(42, result.Data.Folders.First(f => f.FolderPath == duplicatedPath).CaseId);
+        Assert.Equal(99, result.Data.Folders.First(f => f.FolderPath == folderPaths.Last()).CaseId);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains(duplicatedPath) && v.ToString()!.Contains("42, 77")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnrichEgressWorkspacesWithMetadataAsync_WhenWorkspaceLinkedToMultipleCases_EnrichesWithLowestCaseId()
+    {
+        // Arrange
+        var workspaces = CreateSampleWorkspaces(1);
+        var workspaceId = workspaces.Data.First().Id;
+
+        var metadata = new List<CaseMetadata>
+        {
+            new CaseMetadata { CaseId = 8, EgressWorkspaceId = workspaceId },
+            new CaseMetadata { CaseId = 3, EgressWorkspaceId = workspaceId }
+        };
+
+        _caseMetadataServiceMock
+            .Setup(s => s.GetCaseMetadataForEgressWorkspaceIdsAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(metadata);
+
+        // Act
+        var result = await _service.EnrichEgressWorkspacesWithMetadataAsync(workspaces);
+
+        // Assert
+        Assert.Equal(3, result.Data.Single().CaseId);
+    }
+
+    [Fact]
     public async Task EnrichNetAppFoldersWithMetadataAsync_WhenNoFoldersProvided_ReturnsEmptyCollection()
     {
         // Arrange

--- a/backend/CPS.ComplexCases.API/Services/CaseEnrichmentService.cs
+++ b/backend/CPS.ComplexCases.API/Services/CaseEnrichmentService.cs
@@ -73,9 +73,7 @@ public class CaseEnrichmentService : ICaseEnrichmentService
         {
             var workspaceIds = workspaces.Data.Select(w => w.Id).ToList();
             var metadata = await _caseMetadataService.GetCaseMetadataForEgressWorkspaceIdsAsync(workspaceIds);
-            var metadataLookup = metadata
-                .Where(m => m.EgressWorkspaceId != null)
-                .ToDictionary(m => m.EgressWorkspaceId!);
+            var metadataLookup = BuildMetadataLookup(metadata, m => m.EgressWorkspaceId, "Egress workspace");
 
             // Enrich data with metadata
             response.Data = workspaces.Data.Select(workspace => new ListWorkspaceDataResponse
@@ -120,9 +118,7 @@ public class CaseEnrichmentService : ICaseEnrichmentService
                 .ToList();
 
             var metadata = await _caseMetadataService.GetCaseMetadataForNetAppFolderPathsAsync(lookupPaths);
-            var metadataLookup = metadata
-                .Where(m => m.NetappFolderPath != null)
-                .ToDictionary(m => m.NetappFolderPath!);
+            var metadataLookup = BuildMetadataLookup(metadata, m => m.NetappFolderPath, "NetApp folder path");
 
             // Enrich data with metadata
             response.Data = new ListNetAppObjectsDataResponse
@@ -143,6 +139,36 @@ public class CaseEnrichmentService : ICaseEnrichmentService
             _logger.LogWarning(ex, "Failed to retrieve or apply metadata for NetApp folders");
             return response;
         }
+    }
+
+    // Only case_id is unique in case_metadata, so two cases can share a workspace or folder path.
+    // A duplicate must not cost the caller every result on the page, so pick the lowest case id.
+    private Dictionary<string, CaseMetadata> BuildMetadataLookup(
+        IEnumerable<CaseMetadata> metadata,
+        Func<CaseMetadata, string?> keySelector,
+        string keyDescription)
+    {
+        var lookup = new Dictionary<string, CaseMetadata>();
+
+        foreach (var group in metadata.Where(m => keySelector(m) != null).GroupBy(m => keySelector(m)!))
+        {
+            var orderedByCaseId = group.OrderBy(m => m.CaseId).ToList();
+
+            if (orderedByCaseId.Count > 1)
+            {
+                _logger.LogWarning(
+                    "{KeyDescription} {Key} is linked to {CaseCount} cases ({CaseIds}). Using case {CaseId}.",
+                    keyDescription,
+                    group.Key,
+                    orderedByCaseId.Count,
+                    string.Join(", ", orderedByCaseId.Select(m => m.CaseId)),
+                    orderedByCaseId[0].CaseId);
+            }
+
+            lookup[group.Key] = orderedByCaseId[0];
+        }
+
+        return lookup;
     }
 
     private static int? ResolveNetAppFolderCaseId(


### PR DESCRIPTION
# PR checklist

Tick what applies before you raise. Delete anything that doesn't.

## Correctness
- [x] Does what the ticket asks for
- [x] Handles the edge cases (empty, null, zero, large inputs), not just the happy path
- [x] Errors are handled, not swallowed
- [x] New logic has tests, including the failure cases
- [x] Tests assert something real, not just run the code

## Keeping it simple
- [x] Doesn't rebuild something that already exists in the codebase
- [x] No more complex or slower than it needs to be
- [x] No leftover debug logging or commented-out code

## Code Quality
- [x] Pre-commit hooks were run for all commits in this PR

## Easy to miss (a green pipeline won't flag these)
- [x] One logical change, not a pile of unrelated stuff

### If you touched the backend
- [x] Schema changes have a migration, and the Down() doesn't drop anything it shouldn't
- [x] New app settings are wired into the fa-config templates
- [x] Secrets use Key Vault references, not plain text
- [x] New outbound HTTP clients go through the shared resilience handler (AddResiliencePolicyHandler), rather than hand-rolling retries
- [x] New calls to an external service (DDEI, Egress, NetApp) have client tests against a WireMock stub (for the serialisation, auth and error handling) and are covered by the integration tests that run against the real dev services